### PR TITLE
Fix mlx runner file not found error

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,23 @@
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: false
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+  review_status: true
+  commit_status: true
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: true
+  assess_linked_issues: true
+  related_issues: true
+  path_instructions:
+    - path: "**/*.{rs,toml}"
+      instructions:
+        "Review the Rust code for conformity with best practices in Rust,
+        Systems programming. Highlight any deviations."
+

--- a/memgpt.modelfile
+++ b/memgpt.modelfile
@@ -1,0 +1,1 @@
+FROM driaforall/mem-agent

--- a/src/core/modelfile.rs
+++ b/src/core/modelfile.rs
@@ -249,11 +249,11 @@ pub fn parse(input: &str) -> Result<Modelfile, String> {
     }
 }
 
-fn parse_file(input: &str) -> IResult<&str, Vec<(&str, Output)>> {
+fn parse_file(input: &str) -> IResult<&str, Vec<(&str, Output<'_>)>> {
     separated_list1(multispace0, parse_command).parse(input)
 }
 
-fn parse_command(input: &str) -> IResult<&str, (&str, Output)> {
+fn parse_command(input: &str) -> IResult<&str, (&str, Output<'_>)> {
     pair(
         delimited(multispace0, parse_instruction, multispace0),
         alt((

--- a/src/runner/mlx.rs
+++ b/src/runner/mlx.rs
@@ -38,10 +38,22 @@ pub fn run(modelfile: Modelfile) {
         args.push("--adapter-path".to_owned());
         args.push(adapter_path);
     }
-    let mut mlx = Command::new("mlx_lm.chat")
+    let mut mlx = match Command::new("mlx_lm.chat")
         .args(args)
-        .spawn()
-        .expect("mlx runner failed");
+        .spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                eprintln!("❌ Error: mlx_lm.chat command not found");
+                eprintln!("💡 Hint: Install mlx-lm by running: pip install mlx-lm");
+                eprintln!("📝 Note: mlx-lm is only available on macOS with Apple Silicon");
+                std::process::exit(1);
+            } else {
+                eprintln!("❌ Error: Failed to spawn mlx_lm.chat: {}", e);
+                std::process::exit(1);
+            }
+        }
+    };
 
     mlx.wait().expect("wait failed");
 }

--- a/src/runner/mlx.rs
+++ b/src/runner/mlx.rs
@@ -38,9 +38,7 @@ pub fn run(modelfile: Modelfile) {
         args.push("--adapter-path".to_owned());
         args.push(adapter_path);
     }
-    let mut mlx = match Command::new("mlx_lm.chat")
-        .args(args)
-        .spawn() {
+    let mut mlx = match Command::new("mlx_lm.chat").args(args).spawn() {
         Ok(child) => child,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::NotFound {
@@ -55,5 +53,7 @@ pub fn run(modelfile: Modelfile) {
         }
     };
 
-    mlx.wait().expect("wait failed");
+    if let Err(err) = mlx.wait() {
+        eprintln!("❌ Error: Failed to wait for mlx_lm: {}", err);
+    }
 }


### PR DESCRIPTION
Improve MLX runner error handling for the `mlx_lm.chat` command not found and add a test modelfile.

Previously, the MLX runner would panic with a generic "No such file or directory" error when `mlx_lm.chat` was not installed. This change catches the specific `NotFound` error, provides clear installation instructions (`pip install mlx-lm`), and notes the macOS Apple Silicon requirement, allowing the program to exit gracefully with actionable advice.

---
Linear Issue: [TIL-10](https://linear.app/tileshq/issue/TIL-10/bug-mlx-runner-fails-with-no-such-file-or-directory-during)

<a href="https://cursor.com/background-agent?bcId=bc-87a0c3bb-03b5-45d5-a260-fca6874bfd4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-87a0c3bb-03b5-45d5-a260-fca6874bfd4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

