### PR TITLE
Add ISO packaging workflow for CLI installer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,3 +37,18 @@ jobs:
 
     - name: Run check
       run: just check
+
+    - name: Install ISO tooling
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y xorriso
+
+    - name: Build installer ISO
+      run: ./scripts/make_iso.sh
+
+    - name: Upload installer ISO artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: tiles-installer-iso
+        path: dist/*.iso
+        if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .tiles_dev
+dist/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Modelfile-based SDK that lets developers to lets developers customize local mode
 - Go to root and run `just serve` in another terminal to run the server
 - Run the rust cli using cargo as usual
 
+### Packaging installers
+
+- `just bundle` creates a tarball that includes the CLI binary and Python server.
+- `just iso` wraps the bundle and installer script into an ISO that can be flashed with tools like Balena Etcher.
+
 ## License
 
 This project is dual-licensed under MIT and Apache 2.0 terms:

--- a/justfile
+++ b/justfile
@@ -19,3 +19,6 @@ bundle:
 
 install:
     ./scripts/install.sh
+
+iso:
+    ./scripts/make_iso.sh

--- a/scripts/make_iso.sh
+++ b/scripts/make_iso.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="${ROOT_DIR}/dist"
+BINARY_NAME="tiles"
+VERSION=$(grep '^version' "${ROOT_DIR}/Cargo.toml" | head -1 | awk -F'"' '{print $2}')
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+BUNDLE_NAME="${BINARY_NAME}-v${VERSION}-${ARCH}-${OS}.tar.gz"
+BUNDLE_PATH="${DIST_DIR}/${BUNDLE_NAME}"
+ISO_NAME="${BINARY_NAME}-installer-v${VERSION}-${ARCH}-${OS}.iso"
+ISO_PATH="${DIST_DIR}/${ISO_NAME}"
+
+log() { echo -e "\033[1;36m$*\033[0m"; }
+err() { echo -e "\033[1;31m$*\033[0m" >&2; exit 1; }
+
+log "🚀 Preparing ${BINARY_NAME} bundle (${VERSION})..."
+"${ROOT_DIR}/scripts/bundler.sh"
+
+if [[ ! -f "${BUNDLE_PATH}" ]]; then
+  err "Expected bundle ${BUNDLE_PATH} was not created."
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+cp "${ROOT_DIR}/scripts/install.sh" "${TMPDIR}/install.sh"
+chmod +x "${TMPDIR}/install.sh"
+cp "${BUNDLE_PATH}" "${TMPDIR}/${BUNDLE_NAME}"
+
+log "📦 Creating ISO layout..."
+
+ISO_LABEL="tiles-${VERSION}"
+
+create_iso() {
+  local src_dir="$1"
+  local out_path="$2"
+  local label="$3"
+
+  if command -v xorriso >/dev/null 2>&1; then
+    xorriso -as mkisofs -quiet -o "${out_path}" -V "${label}" "${src_dir}"
+  elif command -v genisoimage >/dev/null 2>&1; then
+    genisoimage -quiet -V "${label}" -o "${out_path}" "${src_dir}"
+  elif command -v mkisofs >/dev/null 2>&1; then
+    mkisofs -quiet -V "${label}" -o "${out_path}" "${src_dir}"
+  else
+    err "Could not find xorriso, genisoimage, or mkisofs. Please install one of them to build the ISO."
+  fi
+}
+
+mkdir -p "${DIST_DIR}"
+create_iso "${TMPDIR}" "${ISO_PATH}" "${ISO_LABEL}"
+
+log "✅ ISO created: ${ISO_PATH}"


### PR DESCRIPTION
## Summary
- add a make_iso.sh helper that bundles the CLI installer assets into an ISO
- let the installer reuse local bundles so it works when launched from read-only media
- document the new ISO flow and expose it via a `just iso` recipe

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_690c5a06a514832da70699770e074bf1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an ISO build pipeline and scripts, updates the installer to use local bundles, and documents/exposes the flow via `just iso`.
> 
> - **CI**:
>   - Build and upload installer ISO in `.github/workflows/rust.yml` (installs `xorriso`, runs `scripts/make_iso.sh`, uploads `dist/*.iso`).
> - **Scripts**:
>   - Add `scripts/make_iso.sh` to create an ISO from the installer and bundled assets (uses `xorriso`/`genisoimage`/`mkisofs`).
>   - Update `scripts/install.sh` to support local bundles, `TILES_INSTALL_ENV`, and improved fetching logic.
> - **Dev tooling**:
>   - Add `just iso` recipe to run `scripts/make_iso.sh`.
> - **Docs**:
>   - Document packaging: `just bundle` and `just iso` in `README.md`.
> - **Repo**:
>   - Ignore `dist/` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 225284ab9d66cd3dbbe31035917e8fc9b79098f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->