### PR TITLE
Ensure only tarballs and iso artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .tiles_dev
+/dist

--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -10,6 +10,11 @@ VERSION=$(grep '^version' Cargo.toml | head -1 | awk -F'"' '{print $2}')
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 OUT_NAME="${BINARY_NAME}-v${VERSION}-${ARCH}-${OS}"
+ISO_VOLUME_NAME="Tiles_${VERSION}"
+
+mkdir -p "${DIST_DIR}"
+rm -f "${DIST_DIR}/${OUT_NAME}.tar.gz" "${DIST_DIR}/${OUT_NAME}.iso"
+rm -rf "${DIST_DIR}/tmp"
 
 echo "🚀 Building ${BINARY_NAME} (${TARGET} mode)..."
 cargo build --${TARGET}
@@ -24,6 +29,26 @@ rm -rf "${DIST_DIR}/tmp/server/.venv"
 echo "📦 Creating ${OUT_NAME}.tar.gz..."
 tar -czf "${DIST_DIR}/${OUT_NAME}.tar.gz" -C "${DIST_DIR}/tmp" .
 
+create_iso() {
+  pushd "${DIST_DIR}/tmp" >/dev/null
+  if command -v genisoimage >/dev/null 2>&1; then
+    genisoimage -quiet -o "../${OUT_NAME}.iso" -V "${ISO_VOLUME_NAME}" -R -J .
+  elif command -v mkisofs >/dev/null 2>&1; then
+    mkisofs -quiet -o "../${OUT_NAME}.iso" -V "${ISO_VOLUME_NAME}" -R -J .
+  elif [[ "${OS}" == "darwin" ]] && command -v hdiutil >/dev/null 2>&1; then
+    hdiutil makehybrid -iso -joliet -default-volume-name "${ISO_VOLUME_NAME}" -o "../${OUT_NAME}.iso" . >/dev/null
+  else
+    popd >/dev/null
+    echo "❌ Unable to create ISO image. Install 'genisoimage' (Linux) or ensure 'hdiutil' is available on macOS." >&2
+    exit 1
+  fi
+  popd >/dev/null
+}
+
+echo "💿 Creating ${OUT_NAME}.iso..."
+create_iso
+
 rm -rf "${DIST_DIR}/tmp"
 
 echo "✅ Bundle created: ${DIST_DIR}/${OUT_NAME}.tar.gz"
+echo "✅ Bundle created: ${DIST_DIR}/${OUT_NAME}.iso"


### PR DESCRIPTION
Generate `.tar.gz` and `.iso` distribution artifacts exclusively, and ignore the `dist/` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-76bb63d9-c5ec-450a-bde1-76887ea34121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-76bb63d9-c5ec-450a-bde1-76887ea34121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

