### PR TITLE
feat: add benchmarking harness with TTFT, throughput, and latency metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +130,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -608,6 +636,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +913,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1424,6 +1485,7 @@ name = "tiles"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "futures-util",
  "hf-hub",
@@ -1796,6 +1858,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Any, Dict, List, Optional, Union
+from dataclasses import dataclass
 
 class CompletionRequest(BaseModel):
     model: str
@@ -63,3 +64,12 @@ class StartRequest(BaseModel):
 
 class downloadRequest(BaseModel):
     model: str
+
+
+@dataclass
+class GenerationMetrics:
+    """Benchmarking metrics for token generation."""
+    ttft_ms: float  # Time to first token in milliseconds
+    total_tokens: int  # Total tokens generated
+    tokens_per_second: float  # Throughput
+    total_latency_s: float  # End-to-end latency in seconds

--- a/tiles/Cargo.toml
+++ b/tiles/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { version = "1" , features = ["macros", "rt-multi-thread"]}
 owo-colors = "4"
 futures-util = "0.3"
 hf-hub = {version = "0.4", features = ["tokio"]}
+chrono = "0.4"

--- a/tiles/src/commands/mod.rs
+++ b/tiles/src/commands/mod.rs
@@ -18,3 +18,7 @@ pub async fn start_server(runtime: &Runtime) {
 pub async fn stop_server(runtime: &Runtime) {
     let _ = runtime.stop_server_daemon().await;
 }
+
+pub async fn bench(runtime: &Runtime, run_args: RunArgs) {
+    runtime.bench(run_args).await;
+}

--- a/tiles/src/main.rs
+++ b/tiles/src/main.rs
@@ -22,6 +22,12 @@ enum Commands {
         flags: RunFlags,
     },
 
+    /// Runs a benchmark and saves results to log file
+    Bench {
+        /// Path to the Modelfile (uses default model if not provided)
+        modelfile_path: Option<String>,
+    },
+
     /// Checks the status of dependencies
     Health,
 
@@ -69,6 +75,13 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
                 relay_count: flags.relay_count,
             };
             commands::run(&runtime, run_args).await;
+        }
+        Commands::Bench { modelfile_path } => {
+            let run_args = RunArgs {
+                modelfile_path,
+                relay_count: 0, // unused by bench
+            };
+            commands::bench(&runtime, run_args).await;
         }
         Commands::Health => {
             commands::check_health();

--- a/tiles/src/runtime/cpu.rs
+++ b/tiles/src/runtime/cpu.rs
@@ -23,4 +23,8 @@ impl CPURuntime {
     pub async fn stop_server_daemon(&self) -> Result<()> {
         unimplemented!()
     }
+
+    pub async fn bench(&self, _run_args: super::RunArgs) {
+        unimplemented!()
+    }
 }

--- a/tiles/src/runtime/mlx.rs
+++ b/tiles/src/runtime/mlx.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use futures_util::StreamExt;
 use owo_colors::OwoColorize;
 use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::fs::File;
 use std::io::Write;
@@ -17,15 +18,43 @@ use tokio::time::sleep;
 pub struct MLXRuntime {}
 
 impl MLXRuntime {}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BenchmarkMetrics {
+    ttft_ms: f64,
+    total_tokens: i32,
+    tokens_per_second: f64,
+    total_latency_s: f64,
+}
+
 pub struct ChatResponse {
     // think: String,
     reply: String,
     code: String,
+    metrics: Option<BenchmarkMetrics>,
 }
 
 impl Default for MLXRuntime {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+const DEFAULT_MODELFILE: &str = "FROM driaforall/mem-agent-mlx-4bit";
+
+fn parse_modelfile(modelfile_path: &Option<String>) -> Option<Modelfile> {
+    let parse_result = if let Some(path) = modelfile_path {
+        tilekit::modelfile::parse_from_file(path.as_str())
+    } else {
+        tilekit::modelfile::parse(DEFAULT_MODELFILE)
+    };
+
+    match parse_result {
+        Ok(mf) => Some(mf),
+        Err(_) => {
+            println!("Invalid Modelfile");
+            None
+        }
     }
 }
 
@@ -35,21 +64,8 @@ impl MLXRuntime {
     }
 
     pub async fn run(&self, run_args: super::RunArgs) {
-        const DEFAULT_MODELFILE: &str = "FROM driaforall/mem-agent-mlx-4bit";
-
-        // Parse modelfile
-        let modelfile_parse_result = if let Some(modelfile_str) = &run_args.modelfile_path {
-            tilekit::modelfile::parse_from_file(modelfile_str.as_str())
-        } else {
-            tilekit::modelfile::parse(DEFAULT_MODELFILE)
-        };
-
-        let modelfile = match modelfile_parse_result {
-            Ok(mf) => mf,
-            Err(_err) => {
-                println!("Invalid Modelfile");
-                return;
-            }
+        let Some(modelfile) = parse_modelfile(&run_args.modelfile_path) else {
+            return;
         };
 
         let model = modelfile.from.as_ref().unwrap();
@@ -83,6 +99,7 @@ impl MLXRuntime {
         let child = Command::new(server_path)
             .args(["-m", "server.main"])
             .current_dir(server_dir)
+            .env("PYTHONDONTWRITEBYTECODE", "1") // Disable .pyc caching
             .stdin(Stdio::null())
             .stdout(Stdio::from(stdout_log))
             .stderr(Stdio::from(stderr_log))
@@ -113,6 +130,86 @@ impl MLXRuntime {
         println!("Server stopped.");
         Ok(())
     }
+
+    pub async fn bench(&self, run_args: super::RunArgs) {
+        let Some(modelfile) = parse_modelfile(&run_args.modelfile_path) else {
+            return;
+        };
+
+        let modelname = modelfile.from.as_ref().unwrap();
+
+        // Start server if not running
+        if (ping().await).is_err() {
+            println!("Starting server...");
+            let _res = self.start_server_daemon().await;
+            let _ = wait_until_server_is_up().await;
+        }
+
+        // Load model
+        let memory_path = get_memory_path()
+            .context("Retrieving memory_path failed")
+            .unwrap();
+        if let Err(e) = load_model(modelname, &memory_path).await {
+            println!("Failed to load model: {}", e);
+            return;
+        }
+
+        println!("Running benchmark...");
+
+        // Run benchmark prompt
+        let benchmark_prompt = "What is 2+2? Please answer concisely.";
+        match chat(benchmark_prompt, modelname, true, "").await {
+            Ok(response) => {
+                if let Some(metrics) = response.metrics {
+                    println!("\n{} Benchmark Results:", "✓".green());
+                    println!("  TTFT:       {:.0}ms", metrics.ttft_ms);
+                    println!("  Throughput: {:.1} tok/s", metrics.tokens_per_second);
+                    println!("  Tokens:     {}", metrics.total_tokens);
+                    println!("  Latency:    {:.2}s", metrics.total_latency_s);
+
+                    // Save to log file
+                    save_benchmark_to_log(&metrics, modelname).unwrap_or_else(|e| {
+                        eprintln!("Failed to save benchmark log: {}", e);
+                    });
+                } else {
+                    println!("No metrics returned");
+                }
+            }
+            Err(e) => {
+                println!("Benchmark failed: {}", e);
+            }
+        }
+    }
+}
+
+fn save_benchmark_to_log(metrics: &BenchmarkMetrics, model: &str) -> Result<()> {
+    use chrono::Local;
+
+    let config_dir = get_config_dir()?;
+    let log_file = config_dir.join("benchmark_log.jsonl");
+
+    // Create benchmark log entry
+    let log_entry = serde_json::json!({
+        "timestamp": Local::now().to_rfc3339(),
+        "model": model,
+        "ttft_ms": metrics.ttft_ms,
+        "total_tokens": metrics.total_tokens,
+        "tokens_per_second": metrics.tokens_per_second,
+        "total_latency_s": metrics.total_latency_s,
+    });
+
+    // Append to log file
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_file)?;
+
+    use std::io::Write;
+    writeln!(file, "{}", log_entry)?;
+
+    println!("\n{} Saved to: {}", "💾".cyan(), log_file.display());
+
+    Ok(())
 }
 
 fn run_model_by_sub_process(modelfile: Modelfile) {
@@ -227,6 +324,18 @@ async fn start_repl(mlx_runtime: &MLXRuntime, modelname: &str, run_args: &RunArg
                             } else {
                                 g_reply = response.reply.clone();
                                 println!("\n>> {}", response.reply.trim());
+
+                                // Display benchmark metrics if available
+                                if let Some(metrics) = response.metrics {
+                                    println!(
+                                        "\n{} {:.1} tok/s | {} tokens | {:.0}ms TTFT",
+                                        "💡".yellow(),
+                                        metrics.tokens_per_second,
+                                        metrics.total_tokens,
+                                        metrics.ttft_ms
+                                    );
+                                }
+
                                 break;
                             }
                         } else {
@@ -313,6 +422,7 @@ async fn chat(
 
     let mut stream = res.bytes_stream();
     let mut accumulated = String::new();
+    let mut metrics: Option<BenchmarkMetrics> = None;
     println!();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.unwrap();
@@ -325,10 +435,16 @@ async fn chat(
             let data = line.trim_start_matches("data: ");
 
             if data == "[DONE]" {
-                return Ok(convert_to_chat_response(&accumulated));
+                return Ok(convert_to_chat_response(&accumulated, metrics));
             }
             // Parse JSON
             let v: Value = serde_json::from_str(data).unwrap();
+
+            // Check for metrics in the response
+            if let Some(metrics_obj) = v.get("metrics") {
+                metrics = serde_json::from_value(metrics_obj.clone()).ok();
+            }
+
             if let Some(delta) = v["choices"][0]["delta"]["content"].as_str() {
                 accumulated.push_str(delta);
                 print!("{}", delta.dimmed());
@@ -340,11 +456,11 @@ async fn chat(
     Err(String::from("request failed"))
 }
 
-fn convert_to_chat_response(content: &str) -> ChatResponse {
-    // content.split()
+fn convert_to_chat_response(content: &str, metrics: Option<BenchmarkMetrics>) -> ChatResponse {
     ChatResponse {
         reply: extract_reply(content),
         code: extract_python(content),
+        metrics,
     }
 }
 

--- a/tiles/src/runtime/mod.rs
+++ b/tiles/src/runtime/mod.rs
@@ -37,6 +37,13 @@ impl Runtime {
             Runtime::Cpu(runtime) => runtime.stop_server_daemon().await,
         }
     }
+
+    pub async fn bench(&self, run_args: RunArgs) {
+        match self {
+            Runtime::Mlx(runtime) => runtime.bench(run_args).await,
+            Runtime::Cpu(runtime) => runtime.bench(run_args).await,
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
- Add `tiles bench` command for running benchmarks
- Track TTFT, tokens/sec, total tokens, and latency
- Display metrics after each REPL response
- Save benchmark results to ~/.config/tiles/benchmark_log.jsonl
- Add GenerationMetrics dataclass in Python server, had a little problem with compiling the python code , .env("PYTHONDONTWRITEBYTECODE", "1") // Disable .pyc caching; set this var to 1 @madclaws , if this is a problem we can discuss this as the pycache wasn't getting cleared at all and it somehow was running the old code 