### PR TITLE
feat(server): add VenvStackExecutor for stateful, sandboxed code execution

### DIFF
--- a/server/mem_agent/engine.py
+++ b/server/mem_agent/engine.py
@@ -8,8 +8,13 @@ import types
 import pickle
 import subprocess
 import base64
+import tempfile
+import shutil
+from pathlib import Path
+from typing import Optional, Dict, Any, Tuple
 
 SANDBOX_TIMEOUT = 10
+SANDBOX_PROFILE_PATH = Path(__file__).parent / "sandbox.sb"
 
 # Configure a logger for the sandbox (in real use, configure handlers/level as needed)
 logger = logging.getLogger(__name__)
@@ -302,7 +307,7 @@ def execute_sandboxed_code(
 
     # print("stderr:", result.stderr.decode())
     # print("stdout:", result.stdout[:200])
-    
+
     try:
         local_vars, error_msg = pickle.loads(result.stdout)
     except Exception as e:
@@ -312,6 +317,7 @@ def execute_sandboxed_code(
         error_msg = ""
 
     return local_vars, error_msg
+
 
 def _subprocess_entry() -> None:
     """Entry point for sandbox subprocess."""
@@ -332,3 +338,276 @@ def _subprocess_entry() -> None:
 
 if __name__ == "__main__":
     _subprocess_entry()
+
+
+# =============================================================================
+# VenvStackExecutor: Secure, stateful code execution with venvstacks
+# =============================================================================
+
+
+class VenvStackExecutor:
+    """Secure code executor using venvstacks and Apple sandbox-exec.
+
+    Provides:
+    - Isolated Python virtual environments via venvstacks
+    - Kernel-level sandboxing via Apple's sandbox-exec
+    - Persistent state across tool calls within a session
+    - Automatic package installation
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        workspace_path: str,
+        base_venv_path: Optional[str] = None,
+    ):
+        """Initialize the executor.
+
+        Args:
+            session_id: Unique identifier for this execution session
+            workspace_path: Directory the code is allowed to access
+            base_venv_path: Optional base path for virtual environments
+        """
+        self.session_id = session_id
+        self.workspace_path = os.path.abspath(workspace_path)
+        self.base_venv_path = base_venv_path or os.path.join(
+            tempfile.gettempdir(), "tiles_venvstacks"
+        )
+        self.venv_path = os.path.join(self.base_venv_path, session_id)
+        self._session_state: Dict[str, Any] = {}
+        self._initialized = False
+
+    def _ensure_venv(self) -> None:
+        """Ensure the virtual environment exists."""
+        if self._initialized:
+            return
+
+        os.makedirs(self.venv_path, exist_ok=True)
+
+        # Check if venv already exists
+        python_path = os.path.join(self.venv_path, "bin", "python3")
+        if not os.path.exists(python_path):
+            # Create venv using system Python
+            subprocess.run(
+                [sys.executable, "-m", "venv", self.venv_path],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            logger.info(f"Created venv at {self.venv_path}")
+
+        self._initialized = True
+
+    def _get_sandbox_profile(self) -> str:
+        """Generate sandbox profile with paths substituted."""
+        if not SANDBOX_PROFILE_PATH.exists():
+            logger.warning("Sandbox profile not found, running without sandbox")
+            return ""
+
+        profile = SANDBOX_PROFILE_PATH.read_text()
+        profile = profile.replace("${VENV_PATH}", self.venv_path)
+        profile = profile.replace("${WORKSPACE_PATH}", self.workspace_path)
+        return profile
+
+    def install_package(self, package: str) -> Tuple[bool, str]:
+        """Install a package in the session's venv.
+
+        Args:
+            package: Package name to install
+
+        Returns:
+            Tuple of (success, message)
+        """
+        self._ensure_venv()
+        pip_path = os.path.join(self.venv_path, "bin", "pip")
+
+        try:
+            result = subprocess.run(
+                [pip_path, "install", package],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if result.returncode == 0:
+                return True, f"Successfully installed {package}"
+            else:
+                return False, f"Failed to install {package}: {result.stderr}"
+        except subprocess.TimeoutExpired:
+            return False, f"Timeout installing {package}"
+        except Exception as e:
+            return False, f"Error installing {package}: {e}"
+
+    def execute(
+        self,
+        code: str,
+        timeout: int = SANDBOX_TIMEOUT,
+        use_sandbox: bool = False,  # Disabled by default until sandbox profile is fixed
+    ) -> Tuple[Optional[Dict[str, Any]], str]:
+        """Execute code in the sandboxed environment.
+
+        Args:
+            code: Python code to execute
+            timeout: Maximum execution time in seconds
+            use_sandbox: Whether to use Apple sandbox-exec (macOS only)
+
+        Returns:
+            Tuple of (locals_dict, error_message)
+        """
+        logger.info(f"[SANDBOX] execute() called with code:\n{code[:500]}...")
+
+        self._ensure_venv()
+
+        python_path = os.path.join(self.venv_path, "bin", "python3")
+        logger.debug(f"[SANDBOX] Using python at: {python_path}")
+
+        # Prepare code with state restoration/saving
+        wrapped_code = f"""
+import pickle
+import sys
+import os
+
+# Restore session state
+_session_state = {repr(self._session_state)}
+
+# Make session state available as globals
+globals().update(_session_state)
+
+# Change to workspace
+os.chdir({repr(self.workspace_path)})
+
+# Execute user code
+{code}
+
+# Capture updated state (only picklable values)
+_new_state = {{}}
+for k, v in dict(locals()).items():
+    if not k.startswith("_"):
+        try:
+            pickle.dumps(v)
+            _new_state[k] = v
+        except:
+            pass
+
+# Output state
+sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
+"""
+
+        # Write code to temp file
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False, dir=self.workspace_path
+        ) as f:
+            f.write(wrapped_code)
+            temp_script = f.name
+
+        logger.debug(f"[SANDBOX] Wrote wrapped code to: {temp_script}")
+
+        try:
+            # Build command
+            cmd = [python_path, temp_script]
+
+            # Use sandbox-exec on macOS if available and enabled
+            if use_sandbox and sys.platform == "darwin":
+                profile = self._get_sandbox_profile()
+                if profile:
+                    # Write profile to temp file
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".sb", delete=False
+                    ) as pf:
+                        pf.write(profile)
+                        profile_path = pf.name
+                    cmd = ["sandbox-exec", "-f", profile_path] + cmd
+                    logger.debug(f"[SANDBOX] Using sandbox profile: {profile_path}")
+
+            logger.info(f"[SANDBOX] Executing command: {' '.join(cmd)}")
+
+            # Execute
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                timeout=timeout,
+                cwd=self.workspace_path,
+            )
+
+            logger.debug(f"[SANDBOX] Return code: {result.returncode}")
+            logger.debug(f"[SANDBOX] Stderr: {result.stderr.decode()[:500]}")
+
+            if result.returncode != 0:
+                error_msg = result.stderr.decode().strip()
+                logger.error(f"[SANDBOX] Execution failed: {error_msg}")
+                return None, error_msg
+
+            # Parse output
+            try:
+                new_state, error = pickle.loads(result.stdout)
+                if new_state:
+                    self._session_state.update(new_state)
+                logger.info(
+                    f"[SANDBOX] Execution success: vars={list(new_state.keys())}, error={error}"
+                )
+                return new_state, error or ""
+            except Exception as e:
+                error_msg = (
+                    f"Failed to parse output: {e}\nStderr: {result.stderr.decode()}"
+                )
+                logger.error(f"[SANDBOX] Parse error: {error_msg}")
+                return None, error_msg
+
+        except subprocess.TimeoutExpired:
+            logger.error(f"[SANDBOX] Timeout after {timeout}s")
+            return None, f"Execution timeout ({timeout}s)"
+        except Exception as e:
+            logger.exception(f"[SANDBOX] Exception during execution: {e}")
+            return None, f"Execution error: {e}"
+        finally:
+            # Cleanup temp files
+            try:
+                os.unlink(temp_script)
+                if "profile_path" in locals():
+                    os.unlink(profile_path)
+            except:
+                pass
+
+    def cleanup(self) -> None:
+        """Clean up the session's virtual environment."""
+        if os.path.exists(self.venv_path):
+            try:
+                shutil.rmtree(self.venv_path)
+                logger.info(f"Cleaned up venv at {self.venv_path}")
+            except Exception as e:
+                logger.warning(f"Failed to cleanup venv: {e}")
+
+
+# Session executor cache
+_executor_cache: Dict[str, VenvStackExecutor] = {}
+
+
+def get_or_create_executor(session_id: str, workspace_path: str) -> VenvStackExecutor:
+    """Get or create an executor for a session."""
+    if session_id not in _executor_cache:
+        _executor_cache[session_id] = VenvStackExecutor(session_id, workspace_path)
+    return _executor_cache[session_id]
+
+
+def execute_sandboxed_venvstack(
+    code: str,
+    session_id: str,
+    workspace_path: str,
+    timeout: int = SANDBOX_TIMEOUT,
+    use_sandbox: bool = True,
+) -> Tuple[Optional[Dict[str, Any]], str]:
+    """Execute code using VenvStackExecutor.
+
+    This is the new recommended entry point for sandboxed code execution.
+
+    Args:
+        code: Python code to execute
+        session_id: Session identifier for state persistence
+        workspace_path: Directory the code is allowed to access
+        timeout: Maximum execution time
+        use_sandbox: Whether to use Apple sandbox-exec
+
+    Returns:
+        Tuple of (locals_dict, error_message)
+    """
+    executor = get_or_create_executor(session_id, workspace_path)
+    return executor.execute(code, timeout=timeout, use_sandbox=use_sandbox)

--- a/server/mem_agent/engine.py
+++ b/server/mem_agent/engine.py
@@ -13,7 +13,10 @@ import tempfile
 import shutil
 import threading
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple, Set
+from typing import Optional, Dict, Any, Tuple, Set, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .venvstacks_manager import VenvStacksManager
 
 SANDBOX_TIMEOUT = 10
 SANDBOX_PROFILE_PATH = Path(__file__).parent / "sandbox.sb"
@@ -502,10 +505,17 @@ class VenvStackExecutor:
     """Secure code executor with isolated virtual environments and Apple sandbox-exec.
 
     Provides:
-    - Isolated Python virtual environments per session
+    - Shared venvstacks-based Python environments (when available)
+    - Fallback to per-session virtual environments
     - Kernel-level sandboxing via Apple's sandbox-exec (macOS)
     - Persistent state across tool calls within a session
     - Automatic package installation
+
+    Architecture:
+    - When venvstacks are built/exported, uses shared Python from the
+      application layer (datascience or minimal framework)
+    - When venvstacks are not available, falls back to creating a
+      per-session virtual environment with python -m venv
     """
 
     def __init__(
@@ -513,13 +523,15 @@ class VenvStackExecutor:
         session_id: str,
         workspace_path: str,
         base_venv_path: Optional[str] = None,
+        framework: str = "datascience",
     ):
         """Initialize the executor.
 
         Args:
             session_id: Unique identifier for this execution session
             workspace_path: Directory the code is allowed to access
-            base_venv_path: Optional base path for virtual environments
+            base_venv_path: Optional base path for fallback virtual environments
+            framework: Which venvstacks framework to use ("datascience" or "minimal")
 
         Raises:
             ValueError: If session_id is invalid or paths fail validation
@@ -530,8 +542,9 @@ class VenvStackExecutor:
         self.base_venv_path = base_venv_path or os.path.join(
             tempfile.gettempdir(), "tiles_venvstacks"
         )
+        self.framework = framework
 
-        # Compute venv_path with sanitized session_id
+        # Compute venv_path with sanitized session_id (for fallback mode)
         self.venv_path = os.path.join(self.base_venv_path, self.session_id)
 
         # Verify venv_path is inside base_venv_path (prevent path traversal)
@@ -548,9 +561,20 @@ class VenvStackExecutor:
 
         self._session_state: Dict[str, Any] = {}
         self._initialized = False
+        self._using_venvstacks = False
+        self._venvstacks_python: Optional[Path] = None
+        self._venvstacks_manager: Optional["VenvStacksManager"] = None
 
     def _get_python_path(self) -> str:
-        """Get the path to the Python executable in the venv."""
+        """Get the path to the Python executable.
+
+        Returns venvstacks Python if available, otherwise the fallback venv Python.
+        """
+        # If using venvstacks, return the shared Python path
+        if self._using_venvstacks and self._venvstacks_python:
+            return str(self._venvstacks_python)
+
+        # Fallback: return per-session venv Python
         bin_dir = _get_venv_bin_dir()
         python_name = "python.exe" if sys.platform == "win32" else "python3"
         return os.path.join(self.venv_path, bin_dir, python_name)
@@ -562,14 +586,28 @@ class VenvStackExecutor:
         return os.path.join(self.venv_path, bin_dir, pip_name)
 
     def _ensure_venv(self) -> None:
-        """Ensure the virtual environment exists."""
+        """Ensure a Python environment is available.
+
+        Tries venvstacks first (shared, pre-built environments with data science
+        packages), then falls back to creating a per-session venv if venvstacks
+        are not available.
+        """
         if self._initialized:
             return
 
-        os.makedirs(self.venv_path, exist_ok=True)
-
         # Create session-specific temp directory
         os.makedirs(self.session_temp_path, exist_ok=True)
+
+        # Try venvstacks first
+        if self._try_init_venvstacks():
+            self._initialized = True
+            return
+
+        # Fallback: create per-session venv
+        logger.info(
+            f"Venvstacks not available, creating per-session venv for {self.session_id}"
+        )
+        os.makedirs(self.venv_path, exist_ok=True)
 
         # Check if venv already exists
         python_path = self._get_python_path()
@@ -581,9 +619,55 @@ class VenvStackExecutor:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            logger.info(f"Created venv at {self.venv_path}")
+            logger.info(f"Created fallback venv at {self.venv_path}")
 
         self._initialized = True
+
+    def _try_init_venvstacks(self) -> bool:
+        """Try to initialize using venvstacks.
+
+        Returns:
+            True if venvstacks are available and initialized, False otherwise
+        """
+        try:
+            from .venvstacks_manager import VenvStacksManager, VenvStacksError
+        except ImportError:
+            logger.debug("venvstacks_manager not available")
+            return False
+
+        try:
+            self._venvstacks_manager = VenvStacksManager()
+
+            # Check if stacks are exported or built
+            if not (
+                self._venvstacks_manager.is_exported()
+                or self._venvstacks_manager.is_built()
+            ):
+                logger.debug("Venvstacks not built or exported yet")
+                return False
+
+            # Get Python path from the appropriate application layer
+            python_path = self._venvstacks_manager.get_interpreter_python(
+                self.framework
+            )
+
+            if python_path and python_path.exists():
+                self._venvstacks_python = python_path
+                self._using_venvstacks = True
+                logger.info(f"Using venvstacks Python: {python_path}")
+                return True
+            else:
+                logger.debug(
+                    f"Venvstacks Python not found for framework: {self.framework}"
+                )
+                return False
+
+        except VenvStacksError as e:
+            logger.warning(f"Failed to initialize venvstacks: {e}")
+            return False
+        except Exception as e:
+            logger.debug(f"Unexpected error initializing venvstacks: {e}")
+            return False
 
     def _get_sandbox_profile(self) -> str:
         """Generate sandbox profile with paths substituted.
@@ -598,9 +682,17 @@ class VenvStackExecutor:
             logger.warning("Sandbox profile not found, running without sandbox")
             return ""
 
+        # Determine the Python environment path for sandbox rules
+        # When using venvstacks, use the export directory
+        # When using fallback, use the per-session venv path
+        if self._using_venvstacks and self._venvstacks_manager:
+            python_env_path = str(self._venvstacks_manager.export_dir)
+        else:
+            python_env_path = self.venv_path
+
         # Validate all paths before substitution to prevent sandbox bypass
         paths_to_validate = [
-            ("venv_path", self.venv_path),
+            ("venv_path", python_env_path),
             ("workspace_path", self.workspace_path),
             ("session_temp_path", self.session_temp_path),
         ]
@@ -614,13 +706,17 @@ class VenvStackExecutor:
                 return ""
 
         profile = SANDBOX_PROFILE_PATH.read_text()
-        profile = profile.replace("${VENV_PATH}", self.venv_path)
+        profile = profile.replace("${VENV_PATH}", python_env_path)
         profile = profile.replace("${WORKSPACE_PATH}", self.workspace_path)
         profile = profile.replace("${SESSION_TEMP_PATH}", self.session_temp_path)
         return profile
 
     def install_package(self, package: str) -> Tuple[bool, str]:
-        """Install a package in the session's venv.
+        """Install a package in the session's environment.
+
+        Note: When using venvstacks, package installation is not supported
+        because the shared environments should not be modified. Use the
+        fallback venv mode for custom package installation.
 
         Args:
             package: Package name to install
@@ -629,6 +725,18 @@ class VenvStackExecutor:
             Tuple of (success, message)
         """
         self._ensure_venv()
+
+        # Venvstacks environments are shared and should not be modified
+        if self._using_venvstacks:
+            return (
+                False,
+                f"Cannot install '{package}': using shared venvstacks environment. "
+                f"Pre-installed packages: numpy, pandas, matplotlib, scikit-learn, "
+                f"scipy, seaborn, requests, pillow, sympy (datascience framework) "
+                f"or numpy, requests (minimal framework). "
+                f"To install custom packages, rebuild without venvstacks.",
+            )
+
         pip_path = self._get_pip_path()
 
         try:
@@ -795,22 +903,38 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
                     pass
 
     def cleanup(self) -> None:
-        """Clean up the session's virtual environment and temp directory."""
-        # Clean up venv
-        if os.path.exists(self.venv_path):
+        """Clean up the session's resources.
+
+        When using venvstacks: Only cleans up the session temp directory
+        (the venvstacks Python environment is shared and should not be deleted).
+
+        When using fallback venv: Cleans up both the per-session venv and
+        the session temp directory.
+        """
+        # Only clean up per-session venv if we're NOT using venvstacks
+        # (venvstacks environments are shared across sessions)
+        if not self._using_venvstacks and os.path.exists(self.venv_path):
             try:
                 shutil.rmtree(self.venv_path)
-                logger.info(f"Cleaned up venv at {self.venv_path}")
+                logger.info(f"Cleaned up fallback venv at {self.venv_path}")
             except Exception as e:
                 logger.warning(f"Failed to cleanup venv: {e}")
 
-        # Clean up session temp directory
+        # Always clean up session temp directory
         if os.path.exists(self.session_temp_path):
             try:
                 shutil.rmtree(self.session_temp_path)
                 logger.info(f"Cleaned up session temp at {self.session_temp_path}")
             except Exception as e:
                 logger.warning(f"Failed to cleanup session temp: {e}")
+
+        # Clear session state
+        self._session_state.clear()
+
+    @property
+    def using_venvstacks(self) -> bool:
+        """Check if this executor is using venvstacks (vs fallback venv)."""
+        return self._using_venvstacks
 
 
 # Session executor cache with thread-safe access

--- a/server/mem_agent/engine.py
+++ b/server/mem_agent/engine.py
@@ -1,10 +1,12 @@
 import builtins
+import hashlib
 import importlib
 import io
 import logging
 import os
 import re
 import sys
+import textwrap
 import traceback
 import pickle
 import subprocess
@@ -21,9 +23,9 @@ if TYPE_CHECKING:
 SANDBOX_TIMEOUT = 10
 SANDBOX_PROFILE_PATH = Path(__file__).parent / "sandbox.sb"
 
-# Pattern for validating safe paths (alphanumerics, hyphen, underscore, dot, slash)
+# Pattern for validating safe paths (alphanumerics, hyphen, underscore, dot, slash, space)
 # Rejects sandbox-significant characters: quotes, parentheses, semicolons, newlines, backslashes
-_SAFE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._/\-]+$")
+_SAFE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._/\- ]+$")
 
 # Pattern for validating session IDs (alphanumerics, hyphen, underscore only)
 _SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_\-]+$")
@@ -384,7 +386,8 @@ def _sanitize_session_id(session_id: str) -> str:
     """Sanitize a session ID to prevent path traversal attacks.
 
     Only allows alphanumerics, hyphens, and underscores.
-    Invalid characters are replaced with underscores.
+    Invalid characters are replaced with underscores, and a hash suffix
+    is appended to preserve uniqueness when sanitization changes the input.
 
     Args:
         session_id: The raw session ID
@@ -407,6 +410,11 @@ def _sanitize_session_id(session_id: str) -> str:
 
     # Ensure we don't have path traversal attempts
     sanitized = sanitized.replace("..", "__")
+
+    # Append a hash suffix to preserve uniqueness when sanitization changes input
+    # This prevents collisions like "a/b" and "a_b" mapping to the same sanitized ID
+    hash_suffix = hashlib.sha256(session_id.encode()).hexdigest()[:8]
+    sanitized = f"{sanitized}_{hash_suffix}"
 
     return sanitized
 
@@ -669,36 +677,61 @@ class VenvStackExecutor:
             logger.debug(f"Unexpected error initializing venvstacks: {e}")
             return False
 
-    def _get_sandbox_profile(self) -> str:
+    def _get_sandbox_profile(self, use_sandbox: bool = True) -> str:
         """Generate sandbox profile with paths substituted.
 
         Validates paths before substitution to prevent sandbox rule injection.
+        Fails closed (raises exception) when use_sandbox is True but validation
+        fails, rather than silently disabling the sandbox.
+
+        Args:
+            use_sandbox: Whether sandboxing is required. If True and validation
+                        fails, raises an exception instead of returning empty.
 
         Returns:
-            The sandbox profile with paths substituted, or empty string if
-            the profile is not found or paths fail validation.
+            The sandbox profile with paths substituted.
+
+        Raises:
+            RuntimeError: If use_sandbox is True and the sandbox profile is not
+                         found or path validation fails.
         """
         if not SANDBOX_PROFILE_PATH.exists():
+            if use_sandbox:
+                raise RuntimeError(
+                    f"Sandbox profile not found at {SANDBOX_PROFILE_PATH}. "
+                    "Cannot run with use_sandbox=True."
+                )
             logger.warning("Sandbox profile not found, running without sandbox")
             return ""
 
         # Determine the Python environment path for sandbox rules
-        # When using venvstacks, use the export directory
+        # When using venvstacks, prefer export_dir if exported, else build_dir
         # When using fallback, use the per-session venv path
         if self._using_venvstacks and self._venvstacks_manager:
-            python_env_path = str(self._venvstacks_manager.export_dir)
+            if self._venvstacks_manager.is_exported():
+                python_env_path = str(self._venvstacks_manager.export_dir)
+            elif self._venvstacks_manager.is_built():
+                python_env_path = str(self._venvstacks_manager.build_dir)
+            else:
+                # Shouldn't happen if _using_venvstacks is True, but fallback
+                python_env_path = self.venv_path
         else:
             python_env_path = self.venv_path
 
         # Validate all paths before substitution to prevent sandbox bypass
         paths_to_validate = [
-            ("venv_path", python_env_path),
+            ("python_env_path", python_env_path),
             ("workspace_path", self.workspace_path),
             ("session_temp_path", self.session_temp_path),
         ]
 
         for name, path in paths_to_validate:
             if not _validate_sandbox_path(path):
+                if use_sandbox:
+                    raise ValueError(
+                        f"Sandbox path validation failed for {name}: {path!r} "
+                        "contains unsafe characters. Cannot run with use_sandbox=True."
+                    )
                 logger.warning(
                     f"{name} contains unsafe characters, running without sandbox: "
                     f"{path!r}"
@@ -772,7 +805,16 @@ class VenvStackExecutor:
         Returns:
             Tuple of (locals_dict, error_message)
         """
-        logger.info(f"[SANDBOX] execute() called with code:\n{code[:500]}...")
+        # Log only safe metadata to avoid leaking secrets in user code
+        logger.info("[SANDBOX] execute() called, code_length=%d", len(code))
+        if logger.isEnabledFor(logging.DEBUG):
+            # Redact potential secrets in debug preview
+            redacted_preview = (
+                code[:100].replace("\n", "\\n") + "..."
+                if len(code) > 100
+                else code.replace("\n", "\\n")
+            )
+            logger.debug(f"[SANDBOX] Code preview (redacted): {redacted_preview}")
 
         self._ensure_venv()
 
@@ -783,8 +825,8 @@ class VenvStackExecutor:
         state_b64 = base64.b64encode(pickle.dumps(self._session_state)).decode()
 
         # Prepare code with state restoration/saving
-        wrapped_code = f'''
-import pickle
+        # Build the wrapper script without leading indentation
+        wrapped_code = f"""import pickle
 import base64
 import sys
 import os
@@ -814,7 +856,7 @@ for k, v in dict(locals()).items():
 
 # Output state
 sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
-'''
+"""
 
         # Write code to temp file
         with tempfile.NamedTemporaryFile(
@@ -832,16 +874,15 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
 
             # Use sandbox-exec on macOS if available and enabled
             if use_sandbox and sys.platform == "darwin":
-                profile = self._get_sandbox_profile()
-                if profile:
-                    # Write profile to temp file
-                    with tempfile.NamedTemporaryFile(
-                        mode="w", suffix=".sb", delete=False
-                    ) as pf:
-                        pf.write(profile)
-                        profile_path = pf.name
-                    cmd = ["sandbox-exec", "-f", profile_path] + cmd
-                    logger.debug(f"[SANDBOX] Using sandbox profile: {profile_path}")
+                profile = self._get_sandbox_profile(use_sandbox=True)
+                # Write profile to temp file
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".sb", delete=False
+                ) as pf:
+                    pf.write(profile)
+                    profile_path = pf.name
+                cmd = ["sandbox-exec", "-f", profile_path] + cmd
+                logger.debug(f"[SANDBOX] Using sandbox profile: {profile_path}")
 
             logger.info(f"[SANDBOX] Executing command: {' '.join(cmd)}")
 

--- a/server/mem_agent/engine.py
+++ b/server/mem_agent/engine.py
@@ -1,7 +1,9 @@
 import builtins
 import importlib
+import io
 import logging
 import os
+import re
 import sys
 import traceback
 import pickle
@@ -9,11 +11,19 @@ import subprocess
 import base64
 import tempfile
 import shutil
+import threading
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any, Tuple, Set
 
 SANDBOX_TIMEOUT = 10
 SANDBOX_PROFILE_PATH = Path(__file__).parent / "sandbox.sb"
+
+# Pattern for validating safe paths (alphanumerics, hyphen, underscore, dot, slash)
+# Rejects sandbox-significant characters: quotes, parentheses, semicolons, newlines, backslashes
+_SAFE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9._/\-]+$")
+
+# Pattern for validating session IDs (alphanumerics, hyphen, underscore only)
+_SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_\-]+$")
 
 # Configure a logger for the sandbox (in real use, configure handlers/level as needed)
 logger = logging.getLogger(__name__)
@@ -349,6 +359,145 @@ def _get_venv_bin_dir() -> str:
     return "Scripts" if sys.platform == "win32" else "bin"
 
 
+def _validate_sandbox_path(path: str) -> bool:
+    """Validate a path is safe for sandbox profile substitution.
+
+    Rejects paths containing sandbox-significant characters that could
+    enable sandbox rule injection: quotes, parentheses, semicolons,
+    newlines, backslashes, and other metacharacters.
+
+    Args:
+        path: The path to validate
+
+    Returns:
+        True if the path is safe, False otherwise
+    """
+    if not path:
+        return False
+    return bool(_SAFE_PATH_PATTERN.match(path))
+
+
+def _sanitize_session_id(session_id: str) -> str:
+    """Sanitize a session ID to prevent path traversal attacks.
+
+    Only allows alphanumerics, hyphens, and underscores.
+    Invalid characters are replaced with underscores.
+
+    Args:
+        session_id: The raw session ID
+
+    Returns:
+        Sanitized session ID safe for use in paths
+
+    Raises:
+        ValueError: If session_id is empty or None
+    """
+    if not session_id:
+        raise ValueError("session_id cannot be empty")
+
+    # If already safe, return as-is
+    if _SAFE_SESSION_ID_PATTERN.match(session_id):
+        return session_id
+
+    # Replace unsafe characters with underscores
+    sanitized = re.sub(r"[^A-Za-z0-9_\-]", "_", session_id)
+
+    # Ensure we don't have path traversal attempts
+    sanitized = sanitized.replace("..", "__")
+
+    return sanitized
+
+
+def _validate_path_containment(child_path: str, parent_path: str) -> bool:
+    """Verify that child_path is contained within parent_path.
+
+    Uses secure path normalization to prevent path traversal attacks.
+
+    Args:
+        child_path: The path that should be inside parent_path
+        parent_path: The containing directory
+
+    Returns:
+        True if child_path is inside parent_path, False otherwise
+    """
+    try:
+        child_normalized = os.path.normpath(os.path.abspath(child_path))
+        parent_normalized = os.path.normpath(os.path.abspath(parent_path))
+        common = os.path.commonpath([child_normalized, parent_normalized])
+        return common == parent_normalized
+    except (ValueError, TypeError):
+        return False
+
+
+# Allowed types for RestrictedUnpickler - only safe, basic types
+_PICKLE_SAFE_TYPES: Set[Tuple[str, str]] = {
+    ("builtins", "dict"),
+    ("builtins", "list"),
+    ("builtins", "tuple"),
+    ("builtins", "set"),
+    ("builtins", "frozenset"),
+    ("builtins", "str"),
+    ("builtins", "bytes"),
+    ("builtins", "bytearray"),
+    ("builtins", "int"),
+    ("builtins", "float"),
+    ("builtins", "complex"),
+    ("builtins", "bool"),
+    ("builtins", "type"),
+    ("builtins", "NoneType"),
+    # Allow common safe stdlib types
+    ("datetime", "datetime"),
+    ("datetime", "date"),
+    ("datetime", "time"),
+    ("datetime", "timedelta"),
+    ("decimal", "Decimal"),
+    ("fractions", "Fraction"),
+    ("collections", "OrderedDict"),
+    ("collections", "defaultdict"),
+    ("collections", "Counter"),
+}
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """Restricted unpickler that only allows safe types.
+
+    This prevents arbitrary code execution via pickle deserialization
+    by only allowing a whitelist of safe, basic types.
+
+    Security Note:
+        The subprocess runs user code, so if the sandbox is bypassed,
+        malicious pickle data could be returned. This unpickler limits
+        the damage by preventing deserialization of dangerous types
+        like code objects, functions, or classes.
+    """
+
+    def find_class(self, module: str, name: str) -> type:
+        """Only allow safe types to be unpickled."""
+        if (module, name) in _PICKLE_SAFE_TYPES:
+            return getattr(__import__(module, fromlist=[name]), name)
+
+        # Special case for NoneType which isn't directly importable
+        if module == "builtins" and name == "NoneType":
+            return type(None)
+
+        raise pickle.UnpicklingError(f"Forbidden type in pickle data: {module}.{name}")
+
+
+def _safe_pickle_loads(data: bytes) -> Any:
+    """Safely deserialize pickle data using RestrictedUnpickler.
+
+    Args:
+        data: Pickle-serialized bytes
+
+    Returns:
+        The deserialized object
+
+    Raises:
+        pickle.UnpicklingError: If data contains forbidden types
+    """
+    return RestrictedUnpickler(io.BytesIO(data)).load()
+
+
 class VenvStackExecutor:
     """Secure code executor with isolated virtual environments and Apple sandbox-exec.
 
@@ -371,13 +520,32 @@ class VenvStackExecutor:
             session_id: Unique identifier for this execution session
             workspace_path: Directory the code is allowed to access
             base_venv_path: Optional base path for virtual environments
+
+        Raises:
+            ValueError: If session_id is invalid or paths fail validation
         """
-        self.session_id = session_id
+        # Sanitize session_id to prevent path traversal
+        self.session_id = _sanitize_session_id(session_id)
         self.workspace_path = os.path.abspath(workspace_path)
         self.base_venv_path = base_venv_path or os.path.join(
             tempfile.gettempdir(), "tiles_venvstacks"
         )
-        self.venv_path = os.path.join(self.base_venv_path, session_id)
+
+        # Compute venv_path with sanitized session_id
+        self.venv_path = os.path.join(self.base_venv_path, self.session_id)
+
+        # Verify venv_path is inside base_venv_path (prevent path traversal)
+        if not _validate_path_containment(self.venv_path, self.base_venv_path):
+            raise ValueError(
+                f"Invalid session_id: resulting venv_path escapes base directory"
+            )
+
+        # Session-specific temp directory for sandbox isolation
+        # This prevents cross-session data exposure via temp files
+        self.session_temp_path = os.path.join(
+            tempfile.gettempdir(), "tiles_sessions", self.session_id
+        )
+
         self._session_state: Dict[str, Any] = {}
         self._initialized = False
 
@@ -400,6 +568,9 @@ class VenvStackExecutor:
 
         os.makedirs(self.venv_path, exist_ok=True)
 
+        # Create session-specific temp directory
+        os.makedirs(self.session_temp_path, exist_ok=True)
+
         # Check if venv already exists
         python_path = self._get_python_path()
         if not os.path.exists(python_path):
@@ -415,14 +586,37 @@ class VenvStackExecutor:
         self._initialized = True
 
     def _get_sandbox_profile(self) -> str:
-        """Generate sandbox profile with paths substituted."""
+        """Generate sandbox profile with paths substituted.
+
+        Validates paths before substitution to prevent sandbox rule injection.
+
+        Returns:
+            The sandbox profile with paths substituted, or empty string if
+            the profile is not found or paths fail validation.
+        """
         if not SANDBOX_PROFILE_PATH.exists():
             logger.warning("Sandbox profile not found, running without sandbox")
             return ""
 
+        # Validate all paths before substitution to prevent sandbox bypass
+        paths_to_validate = [
+            ("venv_path", self.venv_path),
+            ("workspace_path", self.workspace_path),
+            ("session_temp_path", self.session_temp_path),
+        ]
+
+        for name, path in paths_to_validate:
+            if not _validate_sandbox_path(path):
+                logger.warning(
+                    f"{name} contains unsafe characters, running without sandbox: "
+                    f"{path!r}"
+                )
+                return ""
+
         profile = SANDBOX_PROFILE_PATH.read_text()
         profile = profile.replace("${VENV_PATH}", self.venv_path)
         profile = profile.replace("${WORKSPACE_PATH}", self.workspace_path)
+        profile = profile.replace("${SESSION_TEMP_PATH}", self.session_temp_path)
         return profile
 
     def install_package(self, package: str) -> Tuple[bool, str]:
@@ -559,15 +753,22 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
                 logger.error(f"[SANDBOX] Execution failed: {error_msg}")
                 return None, error_msg
 
-            # Parse output
+            # Parse output using RestrictedUnpickler for safety
+            # Security Note: The subprocess runs user code. If the sandbox is
+            # bypassed, malicious pickle data could be returned. Using
+            # RestrictedUnpickler limits damage by only allowing safe types.
             try:
-                new_state, error = pickle.loads(result.stdout)
+                new_state, error = _safe_pickle_loads(result.stdout)
                 if new_state:
                     self._session_state.update(new_state)
                 logger.info(
                     f"[SANDBOX] Execution success: vars={list(new_state.keys())}, error={error}"
                 )
                 return new_state, error or ""
+            except pickle.UnpicklingError as e:
+                error_msg = f"Unsafe pickle data rejected: {e}"
+                logger.error(f"[SANDBOX] Security: {error_msg}")
+                return None, error_msg
             except Exception as e:
                 error_msg = (
                     f"Failed to parse output: {e}\nStderr: {result.stderr.decode()}"
@@ -594,7 +795,8 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
                     pass
 
     def cleanup(self) -> None:
-        """Clean up the session's virtual environment."""
+        """Clean up the session's virtual environment and temp directory."""
+        # Clean up venv
         if os.path.exists(self.venv_path):
             try:
                 shutil.rmtree(self.venv_path)
@@ -602,23 +804,54 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
             except Exception as e:
                 logger.warning(f"Failed to cleanup venv: {e}")
 
+        # Clean up session temp directory
+        if os.path.exists(self.session_temp_path):
+            try:
+                shutil.rmtree(self.session_temp_path)
+                logger.info(f"Cleaned up session temp at {self.session_temp_path}")
+            except Exception as e:
+                logger.warning(f"Failed to cleanup session temp: {e}")
 
-# Session executor cache
+
+# Session executor cache with thread-safe access
 _executor_cache: Dict[str, VenvStackExecutor] = {}
+_executor_cache_lock = threading.Lock()
 
 
 def get_or_create_executor(session_id: str, workspace_path: str) -> VenvStackExecutor:
-    """Get or create an executor for a session."""
-    if session_id not in _executor_cache:
-        _executor_cache[session_id] = VenvStackExecutor(session_id, workspace_path)
-    return _executor_cache[session_id]
+    """Get or create an executor for a session (thread-safe).
+
+    Args:
+        session_id: Session identifier (will be sanitized)
+        workspace_path: Directory the code is allowed to access
+
+    Returns:
+        VenvStackExecutor instance for the session
+    """
+    # Sanitize session_id to get the key that VenvStackExecutor will use
+    sanitized_id = _sanitize_session_id(session_id)
+
+    with _executor_cache_lock:
+        if sanitized_id not in _executor_cache:
+            _executor_cache[sanitized_id] = VenvStackExecutor(
+                session_id, workspace_path
+            )
+        return _executor_cache[sanitized_id]
 
 
 def cleanup_executor(session_id: str) -> None:
-    """Clean up and remove an executor from the cache."""
-    if session_id in _executor_cache:
-        _executor_cache[session_id].cleanup()
-        del _executor_cache[session_id]
+    """Clean up and remove an executor from the cache (thread-safe).
+
+    Args:
+        session_id: Session identifier (will be sanitized)
+    """
+    # Sanitize session_id to match the key in cache
+    sanitized_id = _sanitize_session_id(session_id)
+
+    with _executor_cache_lock:
+        if sanitized_id in _executor_cache:
+            _executor_cache[sanitized_id].cleanup()
+            del _executor_cache[sanitized_id]
 
 
 def execute_sandboxed_venvstack(

--- a/server/mem_agent/engine.py
+++ b/server/mem_agent/engine.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 import traceback
-import types
 import pickle
 import subprocess
 import base64
@@ -341,16 +340,21 @@ if __name__ == "__main__":
 
 
 # =============================================================================
-# VenvStackExecutor: Secure, stateful code execution with venvstacks
+# VenvStackExecutor: Secure, stateful code execution with isolated environments
 # =============================================================================
 
 
+def _get_venv_bin_dir() -> str:
+    """Get the correct bin directory name for the current platform."""
+    return "Scripts" if sys.platform == "win32" else "bin"
+
+
 class VenvStackExecutor:
-    """Secure code executor using venvstacks and Apple sandbox-exec.
+    """Secure code executor with isolated virtual environments and Apple sandbox-exec.
 
     Provides:
-    - Isolated Python virtual environments via venvstacks
-    - Kernel-level sandboxing via Apple's sandbox-exec
+    - Isolated Python virtual environments per session
+    - Kernel-level sandboxing via Apple's sandbox-exec (macOS)
     - Persistent state across tool calls within a session
     - Automatic package installation
     """
@@ -377,6 +381,18 @@ class VenvStackExecutor:
         self._session_state: Dict[str, Any] = {}
         self._initialized = False
 
+    def _get_python_path(self) -> str:
+        """Get the path to the Python executable in the venv."""
+        bin_dir = _get_venv_bin_dir()
+        python_name = "python.exe" if sys.platform == "win32" else "python3"
+        return os.path.join(self.venv_path, bin_dir, python_name)
+
+    def _get_pip_path(self) -> str:
+        """Get the path to pip in the venv."""
+        bin_dir = _get_venv_bin_dir()
+        pip_name = "pip.exe" if sys.platform == "win32" else "pip"
+        return os.path.join(self.venv_path, bin_dir, pip_name)
+
     def _ensure_venv(self) -> None:
         """Ensure the virtual environment exists."""
         if self._initialized:
@@ -385,7 +401,7 @@ class VenvStackExecutor:
         os.makedirs(self.venv_path, exist_ok=True)
 
         # Check if venv already exists
-        python_path = os.path.join(self.venv_path, "bin", "python3")
+        python_path = self._get_python_path()
         if not os.path.exists(python_path):
             # Create venv using system Python
             subprocess.run(
@@ -419,7 +435,7 @@ class VenvStackExecutor:
             Tuple of (success, message)
         """
         self._ensure_venv()
-        pip_path = os.path.join(self.venv_path, "bin", "pip")
+        pip_path = self._get_pip_path()
 
         try:
             result = subprocess.run(
@@ -441,14 +457,15 @@ class VenvStackExecutor:
         self,
         code: str,
         timeout: int = SANDBOX_TIMEOUT,
-        use_sandbox: bool = False,  # Disabled by default until sandbox profile is fixed
+        use_sandbox: bool = False,
     ) -> Tuple[Optional[Dict[str, Any]], str]:
         """Execute code in the sandboxed environment.
 
         Args:
             code: Python code to execute
             timeout: Maximum execution time in seconds
-            use_sandbox: Whether to use Apple sandbox-exec (macOS only)
+            use_sandbox: Whether to use Apple sandbox-exec (macOS only).
+                        Defaults to False as sandbox profile may need configuration.
 
         Returns:
             Tuple of (locals_dict, error_message)
@@ -457,17 +474,22 @@ class VenvStackExecutor:
 
         self._ensure_venv()
 
-        python_path = os.path.join(self.venv_path, "bin", "python3")
+        python_path = self._get_python_path()
         logger.debug(f"[SANDBOX] Using python at: {python_path}")
 
+        # Serialize state using base64+pickle for safe transfer (avoids repr issues)
+        state_b64 = base64.b64encode(pickle.dumps(self._session_state)).decode()
+
         # Prepare code with state restoration/saving
-        wrapped_code = f"""
+        wrapped_code = f'''
 import pickle
+import base64
 import sys
 import os
 
-# Restore session state
-_session_state = {repr(self._session_state)}
+# Restore session state safely via pickle
+_state_b64 = "{state_b64}"
+_session_state = pickle.loads(base64.b64decode(_state_b64))
 
 # Make session state available as globals
 globals().update(_session_state)
@@ -485,12 +507,12 @@ for k, v in dict(locals()).items():
         try:
             pickle.dumps(v)
             _new_state[k] = v
-        except:
+        except Exception:
             pass
 
 # Output state
 sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
-"""
+'''
 
         # Write code to temp file
         with tempfile.NamedTemporaryFile(
@@ -501,6 +523,7 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
 
         logger.debug(f"[SANDBOX] Wrote wrapped code to: {temp_script}")
 
+        profile_path: Optional[str] = None
         try:
             # Build command
             cmd = [python_path, temp_script]
@@ -562,10 +585,13 @@ sys.stdout.buffer.write(pickle.dumps((_new_state, None)))
             # Cleanup temp files
             try:
                 os.unlink(temp_script)
-                if "profile_path" in locals():
-                    os.unlink(profile_path)
-            except:
+            except OSError:
                 pass
+            if profile_path:
+                try:
+                    os.unlink(profile_path)
+                except OSError:
+                    pass
 
     def cleanup(self) -> None:
         """Clean up the session's virtual environment."""
@@ -588,23 +614,32 @@ def get_or_create_executor(session_id: str, workspace_path: str) -> VenvStackExe
     return _executor_cache[session_id]
 
 
+def cleanup_executor(session_id: str) -> None:
+    """Clean up and remove an executor from the cache."""
+    if session_id in _executor_cache:
+        _executor_cache[session_id].cleanup()
+        del _executor_cache[session_id]
+
+
 def execute_sandboxed_venvstack(
     code: str,
     session_id: str,
     workspace_path: str,
     timeout: int = SANDBOX_TIMEOUT,
-    use_sandbox: bool = True,
+    use_sandbox: bool = False,
 ) -> Tuple[Optional[Dict[str, Any]], str]:
     """Execute code using VenvStackExecutor.
 
-    This is the new recommended entry point for sandboxed code execution.
+    This is the recommended entry point for sandboxed code execution with
+    state persistence across calls.
 
     Args:
         code: Python code to execute
         session_id: Session identifier for state persistence
         workspace_path: Directory the code is allowed to access
         timeout: Maximum execution time
-        use_sandbox: Whether to use Apple sandbox-exec
+        use_sandbox: Whether to use Apple sandbox-exec (macOS only).
+                    Defaults to False as sandbox profile may need configuration.
 
     Returns:
         Tuple of (locals_dict, error_message)

--- a/server/mem_agent/sandbox.sb
+++ b/server/mem_agent/sandbox.sb
@@ -1,0 +1,81 @@
+;; Tiles Code Interpreter Sandbox Profile
+;; This profile provides kernel-level isolation for code execution
+;; Uses Apple's sandbox-exec for maximum security on macOS
+;;
+;; Template variables (replaced at runtime):
+;;   ${VENV_PATH} - Path to the session's virtual environment
+;;   ${WORKSPACE_PATH} - Path to the user's workspace directory
+
+(version 1)
+
+;; Default: deny all operations
+(deny default)
+
+;; Allow reading system libraries and frameworks
+(allow file-read*
+    (subpath "/usr/lib")
+    (subpath "/usr/share")
+    (subpath "/System/Library")
+    (subpath "/Library/Frameworks")
+    (subpath "/Applications/Xcode.app/Contents/Developer")
+)
+
+;; Allow reading Python installation (Homebrew and system)
+(allow file-read*
+    (subpath "/opt/homebrew")
+    (subpath "/usr/local")
+    (subpath "/usr/bin")
+)
+
+;; Allow read/write to the virtual environment
+(allow file-read* file-write*
+    (subpath "${VENV_PATH}")
+)
+
+;; Allow read/write to the user's workspace
+(allow file-read* file-write*
+    (subpath "${WORKSPACE_PATH}")
+)
+
+;; Allow temporary file operations
+(allow file-read* file-write*
+    (subpath "/private/var/folders")
+    (subpath "/tmp")
+)
+
+;; Allow process execution for Python
+(allow process-exec
+    (subpath "${VENV_PATH}")
+    (subpath "/opt/homebrew")
+    (subpath "/usr/local")
+    (subpath "/usr/bin")
+)
+
+;; Allow forking for subprocess
+(allow process-fork)
+
+;; Allow mach services needed for basic operation
+(allow mach-lookup
+    (global-name "com.apple.system.logger")
+    (global-name "com.apple.system.notification_center")
+)
+
+;; Allow sysctl for system info
+(allow sysctl-read)
+
+;; Allow reading and writing to standard devices
+(allow file-read* file-write*
+    (literal "/dev/null")
+    (literal "/dev/zero")
+    (literal "/dev/urandom")
+    (literal "/dev/random")
+    (literal "/dev/stdin")
+    (literal "/dev/stdout")
+    (literal "/dev/stderr")
+)
+
+;; DENY network access entirely - code execution should be isolated
+(deny network*)
+
+;; Log denied operations for debugging (can be removed in production)
+(trace deny)

--- a/server/mem_agent/sandbox.sb
+++ b/server/mem_agent/sandbox.sb
@@ -5,6 +5,12 @@
 ;; Template variables (replaced at runtime):
 ;;   ${VENV_PATH} - Path to the session's virtual environment
 ;;   ${WORKSPACE_PATH} - Path to the user's workspace directory
+;;   ${SESSION_TEMP_PATH} - Session-specific temp directory
+;;
+;; Security Notes:
+;; - All paths are validated before substitution to prevent injection
+;; - Network access is completely denied
+;; - File access is restricted to session-specific directories
 
 (version 1)
 
@@ -37,10 +43,10 @@
     (subpath "${WORKSPACE_PATH}")
 )
 
-;; Allow temporary file operations
+;; Allow temporary file operations ONLY in the session-specific temp directory
+;; This prevents cross-session data exposure
 (allow file-read* file-write*
-    (subpath "/private/var/folders")
-    (subpath "/tmp")
+    (subpath "${SESSION_TEMP_PATH}")
 )
 
 ;; Allow process execution for Python

--- a/server/mem_agent/venvstacks.toml
+++ b/server/mem_agent/venvstacks.toml
@@ -1,0 +1,76 @@
+# Tiles Code Interpreter Environment Stack
+#
+# This defines portable, layered Python environments for code execution:
+# - Runtime: Base Python with core scientific packages
+# - Framework: Data science packages (numpy, pandas, matplotlib, etc.)
+# - Application: Per-session lightweight environments
+#
+# Build with: venvstacks build mem_agent/venvstacks.toml
+# Export with: venvstacks local-export --output-dir .tiles_stacks mem_agent/venvstacks.toml
+
+[[runtimes]]
+name = "cpython-3.13"
+python_implementation = "cpython@3.13"
+# Core packages needed by the interpreter itself
+requirements = []
+
+[[frameworks]]
+name = "datascience"
+runtime = "cpython-3.13"
+requirements = [
+    # Core scientific computing
+    "numpy",
+    "scipy",
+    # Data manipulation
+    "pandas",
+    # Visualization
+    "matplotlib",
+    "seaborn",
+    # Machine learning basics
+    "scikit-learn",
+    # Utilities
+    "requests",
+    "pillow",
+    "sympy",
+]
+platforms = [
+    "macosx_arm64",
+    "macosx_x86_64",
+    "linux_x86_64",
+    "linux_aarch64",
+    "win_amd64",
+]
+
+[[frameworks]]
+name = "minimal"
+runtime = "cpython-3.13"
+# Minimal framework for lightweight code execution
+requirements = [
+    "numpy",
+    "requests",
+]
+platforms = [
+    "macosx_arm64",
+    "macosx_x86_64", 
+    "linux_x86_64",
+    "linux_aarch64",
+    "win_amd64",
+]
+
+[[applications]]
+name = "interpreter"
+# Full-featured interpreter with data science stack
+frameworks = ["datascience"]
+launch_module = "tiles_interpreter"
+requirements = []
+
+[[applications]]
+name = "interpreter-minimal"
+# Lightweight interpreter for quick tasks
+frameworks = ["minimal"]
+launch_module = "tiles_interpreter"
+requirements = []
+
+[tool.uv]
+# Lock to a specific date for reproducibility
+exclude-newer = "2026-01-20T00:00:00Z"

--- a/server/mem_agent/venvstacks_manager.py
+++ b/server/mem_agent/venvstacks_manager.py
@@ -1,0 +1,394 @@
+"""VenvStacks Manager for portable Python environment stacks.
+
+This module provides integration with venvstacks for creating portable,
+layered Python environments for code execution.
+
+Key concepts:
+- Runtime: Base Python installation
+- Framework: Shared packages (numpy, pandas, etc.) reused across sessions
+- Application: Per-session lightweight environments inheriting from frameworks
+
+Usage:
+    manager = VenvStacksManager()
+
+    # One-time setup: build the stacks
+    manager.build_stacks()
+
+    # Export to a deployment location
+    manager.export_stacks("/path/to/deployment")
+
+    # Get the Python executable for a session
+    python_path = manager.get_interpreter_python("datascience")
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional, Dict, Any, Tuple, List
+
+logger = logging.getLogger(__name__)
+
+# Path to the venvstacks.toml configuration
+VENVSTACKS_CONFIG = Path(__file__).parent / "venvstacks.toml"
+
+# Default locations for built and exported stacks
+DEFAULT_BUILD_DIR = Path(__file__).parent.parent / ".venvstacks_build"
+DEFAULT_EXPORT_DIR = Path(__file__).parent.parent / ".venvstacks_export"
+
+
+class VenvStacksError(Exception):
+    """Base exception for venvstacks-related errors."""
+
+    pass
+
+
+class VenvStacksManager:
+    """Manages venvstacks-based portable Python environments.
+
+    This class provides a high-level interface for:
+    - Building venvstacks from the configuration
+    - Exporting stacks for deployment
+    - Getting Python paths for code execution
+    - Managing stack lifecycle
+    """
+
+    def __init__(
+        self,
+        config_path: Optional[Path] = None,
+        build_dir: Optional[Path] = None,
+        export_dir: Optional[Path] = None,
+    ):
+        """Initialize the VenvStacks manager.
+
+        Args:
+            config_path: Path to venvstacks.toml (defaults to bundled config)
+            build_dir: Directory for built environments
+            export_dir: Directory for exported/deployed environments
+        """
+        self.config_path = Path(config_path) if config_path else VENVSTACKS_CONFIG
+        self.build_dir = Path(build_dir) if build_dir else DEFAULT_BUILD_DIR
+        self.export_dir = Path(export_dir) if export_dir else DEFAULT_EXPORT_DIR
+
+        if not self.config_path.exists():
+            raise VenvStacksError(f"Config not found: {self.config_path}")
+
+    def _run_venvstacks(
+        self,
+        command: List[str],
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        """Run a venvstacks CLI command.
+
+        Args:
+            command: Command and arguments to pass to venvstacks
+            check: Whether to raise on non-zero exit
+
+        Returns:
+            CompletedProcess result
+        """
+        full_cmd = [sys.executable, "-m", "venvstacks"] + command
+        logger.info(f"Running: {' '.join(full_cmd)}")
+
+        result = subprocess.run(
+            full_cmd,
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            logger.error(f"venvstacks failed: {result.stderr}")
+            if check:
+                raise VenvStacksError(f"venvstacks command failed: {result.stderr}")
+
+        return result
+
+    def lock_stacks(self) -> bool:
+        """Lock the stack dependencies.
+
+        This resolves all package versions and creates lock files.
+        Should be run once when dependencies change.
+
+        Returns:
+            True if successful
+        """
+        logger.info("Locking venvstacks dependencies...")
+        result = self._run_venvstacks(
+            [
+                "lock",
+                str(self.config_path),
+            ]
+        )
+        return result.returncode == 0
+
+    def build_stacks(self, lock_first: bool = True) -> bool:
+        """Build the environment stacks.
+
+        This creates all runtime, framework, and application environments.
+
+        Args:
+            lock_first: Whether to lock dependencies before building
+
+        Returns:
+            True if successful
+        """
+        logger.info(f"Building venvstacks to {self.build_dir}...")
+
+        # Ensure build directory exists
+        self.build_dir.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["build", str(self.config_path)]
+        if lock_first:
+            cmd.append("--lock")
+
+        result = self._run_venvstacks(cmd)
+        return result.returncode == 0
+
+    def export_stacks(
+        self,
+        output_dir: Optional[Path] = None,
+        include: Optional[List[str]] = None,
+    ) -> bool:
+        """Export stacks for local deployment.
+
+        This copies built environments to a deployment location and runs
+        post-installation to configure them.
+
+        Args:
+            output_dir: Destination directory (defaults to export_dir)
+            include: List of layer patterns to include (e.g., ["app-interpreter"])
+
+        Returns:
+            True if successful
+        """
+        dest = Path(output_dir) if output_dir else self.export_dir
+        logger.info(f"Exporting venvstacks to {dest}...")
+
+        dest.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "local-export",
+            "--output-dir",
+            str(dest),
+            str(self.config_path),
+        ]
+
+        if include:
+            for pattern in include:
+                cmd.extend(["--include", pattern])
+
+        result = self._run_venvstacks(cmd)
+        return result.returncode == 0
+
+    def get_stack_status(self) -> Dict[str, Any]:
+        """Get the current status of all stacks.
+
+        Returns:
+            Dictionary with stack status information
+        """
+        result = self._run_venvstacks(
+            [
+                "show",
+                "--json",
+                str(self.config_path),
+            ],
+            check=False,
+        )
+
+        if result.returncode == 0 and result.stdout:
+            try:
+                return json.loads(result.stdout)
+            except json.JSONDecodeError:
+                pass
+
+        return {"error": "Failed to get stack status"}
+
+    def is_built(self) -> bool:
+        """Check if stacks have been built.
+
+        Returns:
+            True if build directory exists with environments
+        """
+        if not self.build_dir.exists():
+            return False
+
+        # Check for at least one runtime directory
+        runtimes_dir = self.build_dir / "runtimes"
+        return runtimes_dir.exists() and any(runtimes_dir.iterdir())
+
+    def is_exported(self) -> bool:
+        """Check if stacks have been exported.
+
+        Returns:
+            True if export directory exists with environments
+        """
+        if not self.export_dir.exists():
+            return False
+
+        # Check for metadata directory
+        metadata_dir = self.export_dir / "__venvstacks__"
+        return metadata_dir.exists()
+
+    def get_layer_python(
+        self,
+        layer_name: str,
+        layer_type: str = "applications",
+    ) -> Optional[Path]:
+        """Get the Python executable path for a layer.
+
+        Args:
+            layer_name: Name of the layer (e.g., "interpreter")
+            layer_type: Type of layer ("runtimes", "frameworks", "applications")
+
+        Returns:
+            Path to Python executable, or None if not found
+        """
+        # Check exported environments first
+        if self.is_exported():
+            base_dir = self.export_dir
+        elif self.is_built():
+            base_dir = self.build_dir
+        else:
+            return None
+
+        # Construct environment path based on layer type
+        if layer_type == "runtimes":
+            env_name = layer_name
+        elif layer_type == "frameworks":
+            env_name = f"framework-{layer_name}"
+        else:  # applications
+            env_name = f"app-{layer_name}"
+
+        env_path = base_dir / env_name
+
+        if not env_path.exists():
+            logger.warning(f"Layer environment not found: {env_path}")
+            return None
+
+        # Read layer config to get Python path
+        layer_config = (
+            env_path / "share" / "venv" / "metadata" / "venvstacks_layer.json"
+        )
+        if layer_config.exists():
+            try:
+                config = json.loads(layer_config.read_text())
+                python_rel = config.get("python")
+                if python_rel:
+                    python_path = env_path / python_rel
+                    if python_path.exists():
+                        return python_path
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.warning(f"Failed to read layer config: {e}")
+
+        # Fallback: try standard locations
+        if sys.platform == "win32":
+            candidates = [
+                env_path / "Scripts" / "python.exe",
+                env_path / "python.exe",
+            ]
+        else:
+            candidates = [
+                env_path / "bin" / "python3",
+                env_path / "bin" / "python",
+            ]
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+
+        return None
+
+    def get_interpreter_python(
+        self,
+        framework: str = "datascience",
+    ) -> Optional[Path]:
+        """Get the Python path for the interpreter application.
+
+        This is the main entry point for code execution.
+
+        Args:
+            framework: Which framework to use ("datascience" or "minimal")
+
+        Returns:
+            Path to Python executable for code interpreter
+        """
+        if framework == "minimal":
+            return self.get_layer_python("interpreter-minimal", "applications")
+        else:
+            return self.get_layer_python("interpreter", "applications")
+
+    def cleanup(self) -> None:
+        """Clean up built and exported environments."""
+        import shutil
+
+        if self.build_dir.exists():
+            try:
+                shutil.rmtree(self.build_dir)
+                logger.info(f"Cleaned up build directory: {self.build_dir}")
+            except Exception as e:
+                logger.warning(f"Failed to cleanup build: {e}")
+
+        if self.export_dir.exists():
+            try:
+                shutil.rmtree(self.export_dir)
+                logger.info(f"Cleaned up export directory: {self.export_dir}")
+            except Exception as e:
+                logger.warning(f"Failed to cleanup export: {e}")
+
+
+# Global manager instance (lazy initialization)
+_global_manager: Optional[VenvStacksManager] = None
+
+
+def get_venvstacks_manager() -> VenvStacksManager:
+    """Get or create the global VenvStacksManager instance."""
+    global _global_manager
+    if _global_manager is None:
+        _global_manager = VenvStacksManager()
+    return _global_manager
+
+
+def ensure_stacks_ready(
+    framework: str = "datascience",
+    force_rebuild: bool = False,
+) -> Tuple[bool, str]:
+    """Ensure venvstacks are built and ready for use.
+
+    This is the main initialization function. Call this before
+    using venvstacks-based execution.
+
+    Args:
+        framework: Which framework stack to ensure ("datascience" or "minimal")
+        force_rebuild: Force rebuild even if stacks exist
+
+    Returns:
+        Tuple of (success, message)
+    """
+    manager = get_venvstacks_manager()
+
+    if manager.is_exported() and not force_rebuild:
+        python = manager.get_interpreter_python(framework)
+        if python and python.exists():
+            return True, f"Stacks ready at {manager.export_dir}"
+
+    try:
+        # Build stacks
+        if not manager.is_built() or force_rebuild:
+            logger.info("Building venvstacks (this may take a while)...")
+            if not manager.build_stacks():
+                return False, "Failed to build venvstacks"
+
+        # Export for deployment
+        if not manager.is_exported() or force_rebuild:
+            logger.info("Exporting venvstacks for deployment...")
+            if not manager.export_stacks():
+                return False, "Failed to export venvstacks"
+
+        return True, f"Stacks ready at {manager.export_dir}"
+
+    except VenvStacksError as e:
+        return False, str(e)
+    except Exception as e:
+        return False, f"Unexpected error: {e}"

--- a/server/mem_agent/venvstacks_manager.py
+++ b/server/mem_agent/venvstacks_manager.py
@@ -208,15 +208,18 @@ class VenvStacksManager:
     def is_built(self) -> bool:
         """Check if stacks have been built.
 
+        The venvstacks CLI writes output into a "__venvstacks__" subfolder,
+        so we check for that marker directory.
+
         Returns:
             True if build directory exists with environments
         """
         if not self.build_dir.exists():
             return False
 
-        # Check for at least one runtime directory
-        runtimes_dir = self.build_dir / "runtimes"
-        return runtimes_dir.exists() and any(runtimes_dir.iterdir())
+        # The venvstacks CLI creates a __venvstacks__ subfolder with metadata
+        venvstacks_marker = self.build_dir / "__venvstacks__"
+        return venvstacks_marker.exists()
 
     def is_exported(self) -> bool:
         """Check if stacks have been exported.
@@ -368,10 +371,24 @@ def ensure_stacks_ready(
     """
     manager = get_venvstacks_manager()
 
-    if manager.is_exported() and not force_rebuild:
+    def _validate_interpreter() -> Tuple[bool, str]:
+        """Validate that the interpreter exists and is usable."""
         python = manager.get_interpreter_python(framework)
         if python and python.exists():
             return True, f"Stacks ready at {manager.export_dir}"
+        return False, (
+            f"Interpreter not found for framework '{framework}' at {manager.export_dir}. "
+            f"Expected Python at: {python}"
+        )
+
+    # Check if already exported and valid
+    if manager.is_exported() and not force_rebuild:
+        valid, msg = _validate_interpreter()
+        if valid:
+            return True, msg
+        # Interpreter missing despite being exported - attempt rebuild
+        logger.warning(f"Exported stacks invalid: {msg}. Attempting rebuild...")
+        force_rebuild = True
 
     try:
         # Build stacks
@@ -385,6 +402,11 @@ def ensure_stacks_ready(
             logger.info("Exporting venvstacks for deployment...")
             if not manager.export_stacks():
                 return False, "Failed to export venvstacks"
+
+        # Validate interpreter after build/export
+        valid, msg = _validate_interpreter()
+        if not valid:
+            return False, msg
 
         return True, f"Stacks ready at {manager.export_dir}"
 

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "mlx-lm",
     "black",
     "huggingface-hub>=0.34.0",
+    "venvstacks>=0.2.0",
 ]
 
 [build-system]

--- a/server/tests/test_venvstack_sandbox.py
+++ b/server/tests/test_venvstack_sandbox.py
@@ -15,7 +15,11 @@ import pytest
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from mem_agent.engine import VenvStackExecutor, execute_sandboxed_venvstack
+from mem_agent.engine import (
+    VenvStackExecutor,
+    execute_sandboxed_venvstack,
+    cleanup_executor,
+)
 
 
 class TestVenvStackExecutor:
@@ -177,6 +181,8 @@ class TestExecuteSandboxedVenvstack:
         """Clean up after tests."""
         import shutil
 
+        # Clean up executor from cache
+        cleanup_executor("convenience_test")
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 

--- a/server/tests/test_venvstack_sandbox.py
+++ b/server/tests/test_venvstack_sandbox.py
@@ -149,7 +149,7 @@ try:
 except Exception:
     network_allowed = False
 """
-        result, error = self.executor.execute(code, use_sandbox=True)
+        result, _error = self.executor.execute(code, use_sandbox=True)
 
         # Either the sandbox blocks it or we get an error
         if result is not None:
@@ -169,7 +169,7 @@ try:
 except Exception:
     file_access_denied = True
 """
-        result, error = self.executor.execute(code, use_sandbox=True)
+        result, _error = self.executor.execute(code, use_sandbox=True)
 
         if result is not None:
             assert result.get("file_access_denied") is True
@@ -219,10 +219,24 @@ class TestSecurityHelpers:
         assert _sanitize_session_id("session-123") == "session-123"
 
     def test_sanitize_session_id_invalid_chars(self):
-        """Test that invalid characters are replaced."""
-        assert _sanitize_session_id("abc/123") == "abc_123"
-        assert _sanitize_session_id("session..id") == "session__id"
-        assert _sanitize_session_id("test@user") == "test_user"
+        """Test that invalid characters are replaced and hash suffix added."""
+        import hashlib
+
+        # When sanitization changes input, a hash suffix is appended for uniqueness
+        result1 = _sanitize_session_id("abc/123")
+        assert result1.startswith("abc_123_")
+        expected_hash1 = hashlib.sha256("abc/123".encode()).hexdigest()[:8]
+        assert result1 == f"abc_123_{expected_hash1}"
+
+        result2 = _sanitize_session_id("session..id")
+        assert result2.startswith("session__id_")
+        expected_hash2 = hashlib.sha256("session..id".encode()).hexdigest()[:8]
+        assert result2 == f"session__id_{expected_hash2}"
+
+        result3 = _sanitize_session_id("test@user")
+        assert result3.startswith("test_user_")
+        expected_hash3 = hashlib.sha256("test@user".encode()).hexdigest()[:8]
+        assert result3 == f"test_user_{expected_hash3}"
 
     def test_sanitize_session_id_empty(self):
         """Test that empty session IDs raise ValueError."""
@@ -234,6 +248,8 @@ class TestSecurityHelpers:
         assert _validate_sandbox_path("/tmp/test") is True
         assert _validate_sandbox_path("/Users/test/workspace") is True
         assert _validate_sandbox_path("/var/folders/abc-123") is True
+        # Spaces are now allowed
+        assert _validate_sandbox_path("/Users/test/My Documents") is True
 
     def test_validate_sandbox_path_invalid(self):
         """Test paths with dangerous characters fail validation."""

--- a/server/tests/test_venvstack_sandbox.py
+++ b/server/tests/test_venvstack_sandbox.py
@@ -1,0 +1,198 @@
+"""Tests for VenvStackExecutor sandbox functionality.
+
+Verifies:
+- Isolated environment creation
+- Network access denial
+- File system restriction
+- State persistence across executions
+"""
+
+import os
+import sys
+import tempfile
+import pytest
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from mem_agent.engine import VenvStackExecutor, execute_sandboxed_venvstack
+
+
+class TestVenvStackExecutor:
+    """Test suite for VenvStackExecutor."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.session_id = "test_session_123"
+        self.executor = VenvStackExecutor(
+            session_id=self.session_id,
+            workspace_path=self.temp_dir,
+        )
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        self.executor.cleanup()
+        import shutil
+
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_basic_execution(self):
+        """Test basic code execution works."""
+        code = "x = 1 + 1"
+        result, error = self.executor.execute(code, use_sandbox=False)
+
+        assert error == ""
+        assert result is not None
+        assert result.get("x") == 2
+
+    def test_math_sqrt_execution(self):
+        """Test math.sqrt execution - the most common code interpreter use case."""
+        code = """import math
+result = math.sqrt(123456789)
+"""
+        result, error = self.executor.execute(code, use_sandbox=False)
+
+        assert error == "", f"Unexpected error: {error}"
+        assert result is not None, "Result should not be None"
+        assert "result" in result, f"'result' not in result dict: {result.keys()}"
+        assert abs(result.get("result") - 11111.1110606) < 0.001, (
+            f"Incorrect sqrt result: {result.get('result')}"
+        )
+
+    def test_import_and_compute(self):
+        """Test that imports work correctly in the sandbox."""
+        code = """import json
+data = json.dumps({"key": "value"})
+parsed = json.loads(data)
+"""
+        result, error = self.executor.execute(code, use_sandbox=False)
+
+        assert error == "", f"Unexpected error: {error}"
+        assert result is not None
+        assert result.get("parsed") == {"key": "value"}
+
+    def test_state_persistence(self):
+        """Test that state persists across executions."""
+        # First execution: set a variable
+        code1 = "counter = 42"
+        result1, error1 = self.executor.execute(code1, use_sandbox=False)
+
+        assert error1 == ""
+        assert result1.get("counter") == 42
+
+        # Second execution: use the variable
+        code2 = "result = counter * 2"
+        result2, error2 = self.executor.execute(code2, use_sandbox=False)
+
+        assert error2 == ""
+        assert result2.get("result") == 84
+
+    def test_file_creation_in_workspace(self):
+        """Test that files can be created in the workspace."""
+        code = """
+with open("test_file.txt", "w") as f:
+    f.write("Hello, sandbox!")
+file_created = True
+"""
+        result, error = self.executor.execute(code, use_sandbox=False)
+
+        assert error == ""
+        assert result.get("file_created") is True
+        assert os.path.exists(os.path.join(self.temp_dir, "test_file.txt"))
+
+    def test_file_read_in_workspace(self):
+        """Test that files can be read from the workspace."""
+        # Create a file first
+        test_file = os.path.join(self.temp_dir, "readable.txt")
+        with open(test_file, "w") as f:
+            f.write("test content")
+
+        code = """
+with open("readable.txt", "r") as f:
+    content = f.read()
+"""
+        result, error = self.executor.execute(code, use_sandbox=False)
+
+        assert error == ""
+        assert result.get("content") == "test content"
+
+    def test_timeout_handling(self):
+        """Test that execution timeout is enforced."""
+        code = """
+import time
+time.sleep(30)  # Should timeout
+"""
+        result, error = self.executor.execute(code, timeout=2, use_sandbox=False)
+
+        assert result is None
+        assert "timeout" in error.lower()
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="sandbox-exec is macOS only")
+    def test_sandbox_network_denied(self):
+        """Test that network access is denied in sandbox mode."""
+        code = """
+import urllib.request
+try:
+    urllib.request.urlopen("https://google.com", timeout=5)
+    network_allowed = True
+except Exception:
+    network_allowed = False
+"""
+        result, error = self.executor.execute(code, use_sandbox=True)
+
+        # Either the sandbox blocks it or we get an error
+        if result is not None:
+            assert result.get("network_allowed") is False
+        else:
+            # Sandbox may have blocked the entire execution
+            pass
+
+    @pytest.mark.skipif(sys.platform != "darwin", reason="sandbox-exec is macOS only")
+    def test_sandbox_file_access_restricted(self):
+        """Test that file access outside workspace is denied."""
+        code = """
+try:
+    with open("/etc/passwd", "r") as f:
+        etc_passwd = f.read()
+    file_access_denied = False
+except Exception:
+    file_access_denied = True
+"""
+        result, error = self.executor.execute(code, use_sandbox=True)
+
+        if result is not None:
+            assert result.get("file_access_denied") is True
+
+
+class TestExecuteSandboxedVenvstack:
+    """Test the convenience function."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        import shutil
+
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_convenience_function(self):
+        """Test execute_sandboxed_venvstack works."""
+        result, error = execute_sandboxed_venvstack(
+            code="y = 5 * 5",
+            session_id="convenience_test",
+            workspace_path=self.temp_dir,
+            use_sandbox=False,
+        )
+
+        assert error == ""
+        assert result is not None
+        assert result.get("y") == 25
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/server/tests/test_venvstack_sandbox.py
+++ b/server/tests/test_venvstack_sandbox.py
@@ -5,12 +5,14 @@ Verifies:
 - Network access denial
 - File system restriction
 - State persistence across executions
+- VenvStacks integration
 """
 
 import os
 import sys
 import tempfile
 import pytest
+from unittest import mock
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -19,6 +21,9 @@ from mem_agent.engine import (
     VenvStackExecutor,
     execute_sandboxed_venvstack,
     cleanup_executor,
+    _sanitize_session_id,
+    _validate_sandbox_path,
+    _validate_path_containment,
 )
 
 
@@ -202,3 +207,166 @@ class TestExecuteSandboxedVenvstack:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestSecurityHelpers:
+    """Test security helper functions."""
+
+    def test_sanitize_session_id_valid(self):
+        """Test that valid session IDs pass through unchanged."""
+        assert _sanitize_session_id("abc123") == "abc123"
+        assert _sanitize_session_id("test_session") == "test_session"
+        assert _sanitize_session_id("session-123") == "session-123"
+
+    def test_sanitize_session_id_invalid_chars(self):
+        """Test that invalid characters are replaced."""
+        assert _sanitize_session_id("abc/123") == "abc_123"
+        assert _sanitize_session_id("session..id") == "session__id"
+        assert _sanitize_session_id("test@user") == "test_user"
+
+    def test_sanitize_session_id_empty(self):
+        """Test that empty session IDs raise ValueError."""
+        with pytest.raises(ValueError):
+            _sanitize_session_id("")
+
+    def test_validate_sandbox_path_valid(self):
+        """Test valid paths pass validation."""
+        assert _validate_sandbox_path("/tmp/test") is True
+        assert _validate_sandbox_path("/Users/test/workspace") is True
+        assert _validate_sandbox_path("/var/folders/abc-123") is True
+
+    def test_validate_sandbox_path_invalid(self):
+        """Test paths with dangerous characters fail validation."""
+        assert _validate_sandbox_path("/tmp/test; rm -rf /") is False
+        assert _validate_sandbox_path("/tmp/test\ninjection") is False
+        assert _validate_sandbox_path("/tmp/test'quote") is False
+        assert _validate_sandbox_path("") is False
+
+    def test_validate_path_containment_valid(self):
+        """Test valid contained paths."""
+        assert _validate_path_containment("/tmp/parent/child", "/tmp/parent") is True
+        assert _validate_path_containment("/tmp/parent", "/tmp/parent") is True
+
+    def test_validate_path_containment_invalid(self):
+        """Test path traversal is blocked."""
+        assert _validate_path_containment("/tmp/other", "/tmp/parent") is False
+        assert (
+            _validate_path_containment("/tmp/parent/../other", "/tmp/parent") is False
+        )
+
+
+class TestVenvStacksIntegration:
+    """Test VenvStacks integration."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        import shutil
+
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_executor_falls_back_when_no_venvstacks(self):
+        """Test that executor falls back to per-session venv when venvstacks not available."""
+        executor = VenvStackExecutor(
+            session_id="test_fallback",
+            workspace_path=self.temp_dir,
+        )
+
+        # Execute to trigger initialization
+        result, error = executor.execute("x = 1", use_sandbox=False)
+
+        # Should work (using fallback venv)
+        assert error == ""
+        assert result is not None
+        assert result.get("x") == 1
+
+        # Check that we're NOT using venvstacks (since they're not built)
+        assert executor.using_venvstacks is False
+
+        executor.cleanup()
+
+    def test_executor_framework_parameter(self):
+        """Test that framework parameter is stored correctly."""
+        executor = VenvStackExecutor(
+            session_id="test_framework",
+            workspace_path=self.temp_dir,
+            framework="minimal",
+        )
+
+        assert executor.framework == "minimal"
+        executor.cleanup()
+
+    def test_install_package_denied_with_venvstacks(self):
+        """Test that package installation is denied when using venvstacks."""
+        executor = VenvStackExecutor(
+            session_id="test_install_denied",
+            workspace_path=self.temp_dir,
+        )
+
+        # Mock venvstacks being available
+        executor._using_venvstacks = True
+        executor._initialized = True
+
+        success, message = executor.install_package("some-package")
+
+        assert success is False
+        assert "Cannot install" in message
+        assert "shared venvstacks" in message
+
+        executor.cleanup()
+
+
+class TestVenvStacksManager:
+    """Test VenvStacksManager class."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        """Clean up after tests."""
+        import shutil
+
+        if os.path.exists(self.temp_dir):
+            shutil.rmtree(self.temp_dir)
+
+    def test_manager_creation(self):
+        """Test VenvStacksManager can be created."""
+        try:
+            from mem_agent.venvstacks_manager import (
+                VenvStacksManager,
+                VENVSTACKS_CONFIG,
+            )
+
+            # Only test if config exists
+            if VENVSTACKS_CONFIG.exists():
+                manager = VenvStacksManager()
+                assert manager.config_path == VENVSTACKS_CONFIG
+        except ImportError:
+            pytest.skip("venvstacks_manager not available")
+
+    def test_manager_not_built_initially(self):
+        """Test that is_built returns False when nothing is built."""
+        try:
+            from mem_agent.venvstacks_manager import (
+                VenvStacksManager,
+                VENVSTACKS_CONFIG,
+            )
+            from pathlib import Path
+
+            if not VENVSTACKS_CONFIG.exists():
+                pytest.skip("venvstacks.toml not found")
+
+            manager = VenvStacksManager(
+                build_dir=Path(self.temp_dir) / "build",
+                export_dir=Path(self.temp_dir) / "export",
+            )
+
+            assert manager.is_built() is False
+            assert manager.is_exported() is False
+        except ImportError:
+            pytest.skip("venvstacks_manager not available")


### PR DESCRIPTION
## Features
- **VenvStackExecutor** class for session-based code execution
- **Shared Python environments** via venvstacks with automatic fallback to per-session venvs
- Persistent state across multiple tool calls within a session
- Kernel-level sandboxing via Apple's sandbox-exec (macOS)
- Automatic cleanup of session environments
- Network access denial and file system restrictions
- Thread-safe executor cache for concurrent sessions

## Security Hardening
- Path injection prevention with strict regex validation
- Path traversal prevention via session ID sanitization
- RestrictedUnpickler for safe deserialization of subprocess output
- Session-isolated temp directories

## VenvStacks Architecture
When venvstacks are built and exported, sessions share pre-built Python environments:
- **Runtime layer**: Python 3.13
- **Framework layers**: `datascience` (numpy, pandas, matplotlib, scikit-learn, scipy, seaborn, requests, pillow, sympy) or `minimal` (numpy, requests)
- **Application layers**: `interpreter` and `interpreter-minimal`

This reduces session startup time and disk usage. Falls back to per-session venvs when stacks aren't available.

## Components
- `engine.py`: VenvStackExecutor class, security helpers, execute_sandboxed_venvstack function
- `venvstacks_manager.py`: VenvStacksManager for building/exporting portable environments
- `venvstacks.toml`: Stack configuration with datascience and minimal frameworks
- `sandbox.sb`: Template sandbox profile for macOS isolation
- `test_venvstack_sandbox.py`: Comprehensive test suite (22 tests)

This provides the foundation for safe, stateful code interpreter functionality.