### PR TITLE
fix: prevent venvstack multiple app-server tar on build + other refactors

### DIFF
--- a/scripts/bundler.sh
+++ b/scripts/bundler.sh
@@ -21,6 +21,9 @@ cargo build -p tiles --${TARGET}
 mkdir -p "${DIST_DIR}/tmp"
 cp "target/${TARGET}/${BINARY_NAME}" "${DIST_DIR}/tmp/"
 
+# flushing this folder, else the final zip will have previous app-server zips too (#84)
+rm -rf "${SERVER_DIR}/stack_export_prod"
+
 echo "🔒 Locking the venvstack...."
 
 venvstacks lock server/stack/venvstacks.toml

--- a/tiles/src/commands/mod.rs
+++ b/tiles/src/commands/mod.rs
@@ -351,7 +351,7 @@ mod tests {
         assert_eq!(FTUE_DATA_DIR_CHANGE_HINT, "Change data path later:");
         assert_eq!(
             FTUE_CUSTOM_DATA_PROMPT,
-            "Use a custom data directory now? [Y/N]"
+            "Use a custom data directory now? [y/N]"
         );
     }
 

--- a/tiles/src/main.rs
+++ b/tiles/src/main.rs
@@ -170,7 +170,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
             commands::run_account_commands(account_args)?;
         }
         Some(Commands::Update) => {
-            println!("trying to update tiles");
+            println!("Checking for updates...");
             let res = installer::try_update(None).await?;
             println!("{}", res);
         }

--- a/tiles/src/runtime/mlx.rs
+++ b/tiles/src/runtime/mlx.rs
@@ -240,7 +240,7 @@ async fn run_model_with_server(
 }
 
 async fn start_repl(mlx_runtime: &MLXRuntime, modelname: &str, run_args: &RunArgs) {
-    println!("Running in interactive mode");
+    println!("Running {} in interactive mode", modelname);
 
     let config = Config::builder().auto_add_history(true).build();
     let mut editor = Editor::<TilesHinter, DefaultHistory>::with_config(config).unwrap();

--- a/tiles/src/utils/installer.rs
+++ b/tiles/src/utils/installer.rs
@@ -36,7 +36,11 @@ pub async fn try_update(update_info: Option<UpdateInfo>) -> Result<String> {
     };
 
     if !app_update_info.can_update {
-        Ok("Already latest version".to_owned())
+        let msg = format!(
+            "You are up to date, current version: {}",
+            app_update_info.current_version
+        );
+        Ok(msg)
     } else {
         let mut curl_process = Command::new("curl")
             .arg("-fsSL")


### PR DESCRIPTION
- Flushing the stack_export_prod folder before building prevents the previous app-server zips getting accumulated in the final tar.

- Fixed broken tests

- Minor refactor