### PR TITLE
Update CLI ASCII art and product copy

### DIFF
--- a/tiles/src/commands/mod.rs
+++ b/tiles/src/commands/mod.rs
@@ -22,24 +22,27 @@ use toml::Table;
 use crate::{AccountArgs, AccountCommands};
 
 const FTUE_VERSION_TITLE: &str = "Tiles";
+const PRODUCT_DESCRIPTION: &str = "Local-first private AI assistant for everyday use.";
 const FTUE_HEADER: &str = "Initializing local account...";
 const FTUE_ASCII_ART: &str = r#"
-              ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
-             ▓▓                      ▓▓░░▓▒
-           ▓▓▓▓▓▓▓▓▓▓▓▓▓     ▓▓▓▓▓▓▓▓▓    ▓▓
-            ▓▓░░░░░░░▓▓░    ▓▓▓░░░░░▓▓   ▓▓
-             ▓▓     ░▓▒    ▓▓ ▓▒     ▒▓░▓▓
-              ▓▓▓▓▓▓▓▒    ▓▓   ▓▓▓▓▓▓▓▓▓▓
-                   ▓▓    ▓▓   ░▓░
-                  ▓▓    ▒▓░   ▓▒
-                 ▒▓    ░▓░   ▓▓
-                ▒▓    ░▓▒   ▓▓
-               ░▓░    ▓▓   ▓▓
-              ░▓▒    ▓▓   ▒▓
-              ▓▓▓▓▓▓▓▓   ▒▓░
-              ░▓▒    ▓▓ ░▓░
-                ▓▓    ▓▓▓▒
-                 ▓▓▓▓▓▓▓▓
+                               .:-::.
+                       .:-+*#%@@@@@@%#**+=
+               .:-=*#%@@@@@%%#***#%%@@@%=.
+       .:-=+#%@@@@@%%##****#%@@@@@@@%*=
+   -#%@@@@@@%#*****#%%@@@@@@%#*=-:.
+ -#@%%#####%%%%@@@%%#@@@@@#.
+-###%@@@@@@@@@%%%%%%@@@@@*
+  ..:--=+##*+==@@@@@@@@@=
+             .#@@@@@@@@:
+            -@@@@@@@@#.
+           +@@@@@%@@*
+          #@@@@#+@@=
+        .%@@@@#+@@:
+       .@@@@@##@#.
+        %@@@#%@*
+        :@@*@@=
+         -+@@:
+          .-.
 "#;
 
 // const FTUE_ASCII_ART_NEW: &str = r#"
@@ -62,7 +65,7 @@ const FTUE_ASCII_ART: &str = r#"
 //           ▓▆▄
 
 // "#;
-const FTUE_REASSURANCE_LOCAL: &str = "On-device by default.";
+const FTUE_REASSURANCE_LOCAL: &str = "Local-first private AI assistant for everyday use";
 // const FTUE_REASSURANCE_NO_CLOUD: &str = "Online models and identity optional.";
 const FTUE_NICKNAME_PROMPT: &str = "Choose a username:";
 const FTUE_NICKNAME_REQUIRED: &str = "Username is required. Please enter a username:";
@@ -97,6 +100,8 @@ pub fn run_setup_for_ftue(_run_args: &RunArgs) -> Result<()> {
         setup_root_account(root_config.clone())?;
         setup_default_user_data_dir(&config_provider)?
     } else {
+        println!("{}", PRODUCT_DESCRIPTION);
+        println!();
         print_runtime_context(&config_provider, &root_user_details)?;
     }
 
@@ -358,8 +363,12 @@ mod tests {
 
     #[test]
     fn ftue_copy_matches_expected_constants() {
+        assert_eq!(
+            PRODUCT_DESCRIPTION,
+            "Local-first private AI assistant for everyday use."
+        );
         assert_eq!(FTUE_HEADER, "Initializing local account...");
-        assert_eq!(FTUE_REASSURANCE_LOCAL, "On-device by default.");
+        assert_eq!(FTUE_REASSURANCE_LOCAL, "Local-first private AI assistant for everyday use");
         assert_eq!(FTUE_NICKNAME_PROMPT, "Choose a username:");
         assert_eq!(FTUE_ACCOUNT_LABEL, "Account");
         assert_eq!(FTUE_ACCOUNT_DETAILS_HINT, "View full details:");

--- a/tiles/src/commands/mod.rs
+++ b/tiles/src/commands/mod.rs
@@ -22,7 +22,7 @@ use toml::Table;
 use crate::{AccountArgs, AccountCommands};
 
 const FTUE_VERSION_TITLE: &str = "Tiles";
-const PRODUCT_DESCRIPTION: &str = "Local-first private AI assistant for everyday use.";
+const PRODUCT_DESCRIPTION: &str = "Local-first private AI assistant for everyday use";
 const FTUE_HEADER: &str = "Initializing local account...";
 const FTUE_ASCII_ART: &str = r#"
                                .:-::.
@@ -365,7 +365,7 @@ mod tests {
     fn ftue_copy_matches_expected_constants() {
         assert_eq!(
             PRODUCT_DESCRIPTION,
-            "Local-first private AI assistant for everyday use."
+            "Local-first private AI assistant for everyday use"
         );
         assert_eq!(FTUE_HEADER, "Initializing local account...");
         assert_eq!(FTUE_REASSURANCE_LOCAL, "Local-first private AI assistant for everyday use");

--- a/tiles/src/commands/mod.rs
+++ b/tiles/src/commands/mod.rs
@@ -368,7 +368,10 @@ mod tests {
             "Local-first private AI assistant for everyday use"
         );
         assert_eq!(FTUE_HEADER, "Initializing local account...");
-        assert_eq!(FTUE_REASSURANCE_LOCAL, "Local-first private AI assistant for everyday use");
+        assert_eq!(
+            FTUE_REASSURANCE_LOCAL,
+            "Local-first private AI assistant for everyday use"
+        );
         assert_eq!(FTUE_NICKNAME_PROMPT, "Choose a username:");
         assert_eq!(FTUE_ACCOUNT_LABEL, "Account");
         assert_eq!(FTUE_ACCOUNT_DETAILS_HINT, "View full details:");

--- a/tiles/src/main.rs
+++ b/tiles/src/main.rs
@@ -19,7 +19,7 @@ use crate::commands::{show_peers, unlink_peer};
 mod commands;
 #[derive(Debug, Parser)]
 #[command(name = "tiles")]
-#[command(version, about = "Your private and secure AI assistant for everyday use.", long_about = None, after_help = "Documentation: https://tiles.run/book\nReport issues: https://github.com/tilesprivacy/tiles/issues")]
+#[command(version, about = "Local-first private AI assistant for everyday use", long_about = None, after_help = "Documentation: https://tiles.run/book\nReport issues: https://github.com/tilesprivacy/tiles/issues")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,


### PR DESCRIPTION
## Summary

- Replace the CLI help product description with `Local-first private AI assistant for everyday use`.
- Add the product description below `Tiles <version>` on normal CLI startup for existing accounts.
- Update the FTUE reassurance copy and ASCII art shown by the CLI startup banner.

## Validation

```sh
cargo test -p tiles commands::tests
cargo run --bin tiles -- -x
```
